### PR TITLE
Rename methods/variables in trie code to clarify behaviour.

### DIFF
--- a/app/src/main/java/com/serwylo/lexica/game/Board.java
+++ b/app/src/main/java/com/serwylo/lexica/game/Board.java
@@ -36,7 +36,7 @@ public abstract class Board implements TransitionMap {
 	}
 
 	public synchronized int valueAt(int i) {
-		return Trie.ctoi(board[i].charAt(0));
+		return Trie.charToOffset(board[i].charAt(0));
 	}
 
 	public synchronized String toString() {

--- a/app/src/main/java/com/serwylo/lexica/game/Game.java
+++ b/app/src/main/java/com/serwylo/lexica/game/Game.java
@@ -225,13 +225,13 @@ public class Game implements Synchronizer.Counter {
 		CompressedTrie dict;
 
 		for(int i=0;i<board.getSize();i++) {
-			int ival = Trie.ctoi(board.elementAt(i).charAt(0));
+			int ival = Trie.charToOffset(board.elementAt(i).charAt(0));
 			mask |= 1<<ival;
 
 			for(int j=0;j<board.getSize();j++) {
 				if((board.transitions(i)&(1<<j))!= 0) {
-					neighborMasks[ival] |= 1<<Trie.ctoi(board.elementAt(j).
-						charAt(0));
+					neighborMasks[ival] |= 1<<Trie.charToOffset(board.elementAt(j).
+							charAt(0));
 				}
 			}
 		}

--- a/libraries/trie/src/main/java/net/healeys/trie/CompressedTrie.java
+++ b/libraries/trie/src/main/java/net/healeys/trie/CompressedTrie.java
@@ -123,26 +123,46 @@ public class CompressedTrie extends Trie {
 	 * The CompressedTrieNode is like a normal TrieNode, but only allocates
 	 * a large enough Array to store the number of children that it is known
 	 * to have.
+	 *
+	 * Thus, the children cannot be indexed by their position in the alphabet as is
+	 * the case in the non-compressed version. Instead,
 	 */
 	protected class CompressedTrieNode extends Trie.TrieNode {
 		public CompressedTrieNode(int cBits) {
 			childBits = cBits;
 			
-			children = new TrieNode[countBits(cBits&LETTER_MASK)];
+			children = new TrieNode[countChildrenFromChildBits()];
 		}
 
-		protected TrieNode childAt(int index) {
-			TrieNode ret = null;
-			int j=0;
-			for(int i=0;i<=index;i++) {
-				if((childBits&(1<<i)) != 0) {
-					ret = children[j];
+		protected TrieNode childAt(int offset) {
+			TrieNode child = null;
+			int j = 0;
+			for(int i = 0; i <= offset; i ++) {
+				if((childBits & (1 << i)) != 0) {
+					child = children[j];
 					j++;
 				} else {
-					ret = null;
+					child = null;
 				}
 			}
-			return ret;
+			return child;
+		}
+
+		/**
+		 * Counts the number of children of this node, by looking at the binary representation
+		 * of the node.
+		 *
+		 * A node is represented in part by the first 26 bits of a 32 bit integer. Given not all
+		 * of these bits are used, this method will count how many of those bits are equal to 1
+		 * (i.e., have children represented by this node).
+		 */
+		private byte countChildrenFromChildBits() {
+			int childBitsToCheck = childBits & LETTER_MASK;
+			byte c = 0;
+			for(childBitsToCheck &= LETTER_MASK; childBitsToCheck > 0;childBitsToCheck >>= 1)
+				if((childBitsToCheck & 1) != 0) c++;
+
+			return c;
 		}
 	}
 

--- a/libraries/trie/src/test/java/com/serwylo/lexica/trie/tests/Utils.java
+++ b/libraries/trie/src/test/java/com/serwylo/lexica/trie/tests/Utils.java
@@ -13,7 +13,7 @@ public class Utils {
 		int mask = 0;
 		for (int i = 0; i < availableLetters.length(); i ++) {
 			char character = availableLetters.charAt(i);
-			mask |= 1 << Trie.ctoi(character);
+			mask |= 1 << Trie.charToOffset(character);
 		}
 		return mask;
 	}


### PR DESCRIPTION
Less usage of abbreviated terms. Also formatted many of the
bit shifting operations to add more whitespace.