### PR TITLE
Enable proguard to reduce apk size

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,8 +22,8 @@ android {
     }
 
     buildTypes {
-        release {
-            minifyEnabled false
+        all {
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,6 +24,7 @@ android {
     buildTypes {
         all {
             minifyEnabled true
+            shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }


### PR DESCRIPTION
Fixes #21 

I've enabled for debug builds as well as release builds. This is so that during testing of debug builds, it should be easier to notice bugs that would affect release builds. If the extra build time becomes a problem for debug builds, then this can be revisited.