### PR TITLE
Add high score tracking

### DIFF
--- a/app/src/main/java/com/serwylo/lexica/Lexica.java
+++ b/app/src/main/java/com/serwylo/lexica/Lexica.java
@@ -93,7 +93,7 @@ public class Lexica extends Activity {
 		});
 		int highScore = ScoreActivity.getHighScore(this);
 		TextView tv = (TextView) findViewById(R.id.high_score);
-		tv.setText(String.format(getResources().getString(R.string.high_score), highScore));
+		tv.setText(getResources().getString(R.string.high_score, highScore));
 	}
 
 	public void onPause() {

--- a/app/src/main/java/com/serwylo/lexica/Lexica.java
+++ b/app/src/main/java/com/serwylo/lexica/Lexica.java
@@ -26,6 +26,7 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.Button;
+import android.widget.TextView;
 
 public class Lexica extends Activity {
 
@@ -62,7 +63,7 @@ public class Lexica extends Activity {
 				public void onClick(View v) {
 					if(savedGame()) {
 						// Log.d(TAG,"restoring game");
-						startActivity(new 
+						startActivity(new
 							Intent("com.serwylo.lexica.action.RESTORE_GAME"));
 					} else {
 						// Log.d(TAG,"no saved game :(");
@@ -86,10 +87,13 @@ public class Lexica extends Activity {
 		b = (Button) findViewById(R.id.preferences);
 		b.setOnClickListener(new View.OnClickListener() {
 			public void onClick(View v) {
-				startActivity(new 
+				startActivity(new
 					Intent("com.serwylo.lexica.action.CONFIGURE"));
 			}
 		});
+		int highScore = ScoreActivity.getHighScore(this);
+		TextView tv = (TextView) findViewById(R.id.high_score);
+		tv.setText(String.format(getResources().getString(R.string.high_score), highScore));
 	}
 
 	public void onPause() {
@@ -113,9 +117,9 @@ public class Lexica extends Activity {
 				return new AlertDialog.Builder(this)
 					.setTitle(getResources().
 						getString(R.string.dialog_no_saved))
-					.setPositiveButton(R.string.dialog_ok, 
+					.setPositiveButton(R.string.dialog_ok,
 						new DialogInterface.OnClickListener() {
-							public void onClick(DialogInterface dialog, 
+							public void onClick(DialogInterface dialog,
 								int whichButton) {
 									// do nothing.
 								}

--- a/app/src/main/java/com/serwylo/lexica/LexicaConfig.java
+++ b/app/src/main/java/com/serwylo/lexica/LexicaConfig.java
@@ -17,12 +17,11 @@
 
 package com.serwylo.lexica;
 
+import android.content.Context;
 import android.content.DialogInterface;
-import android.content.SharedPreferences;
 import android.preference.Preference;
 import android.preference.PreferenceActivity;
 import android.os.Bundle;
-import android.preference.PreferenceManager;
 import android.support.v7.app.AlertDialog;
 import android.widget.Toast;
 
@@ -59,18 +58,7 @@ public class LexicaConfig extends PreferenceActivity implements Preference.OnPre
     };
 
     private void clearHighScores() {
-        SharedPreferences.Editor edit = PreferenceManager.getDefaultSharedPreferences(this).edit();
-        for (String a : getResources().getStringArray(R.array.dict_choices_entryvalues)) {
-            for (String b : getResources().getStringArray(R.array.board_size_choices_entryvalues)) {
-                for (String c : getResources().getStringArray(R.array.time_limit_choices_entryvalues)) {
-                    for (String d : getResources().getStringArray(R.array.score_type_choices_entryvalues)) {
-                        String key = ScoreActivity.HIGH_SCORE_PREFIX + a + b + c + d;
-                        edit.putInt(key, 0);
-                    }
-                }
-            }
-        }
-        edit.commit();
+        getSharedPreferences(ScoreActivity.SCORE_PREF_FILE, Context.MODE_PRIVATE).edit().clear().commit();
         Toast.makeText(this, R.string.high_scores_reset, Toast.LENGTH_SHORT).show();
     }
 }

--- a/app/src/main/java/com/serwylo/lexica/LexicaConfig.java
+++ b/app/src/main/java/com/serwylo/lexica/LexicaConfig.java
@@ -17,15 +17,60 @@
 
 package com.serwylo.lexica;
 
+import android.content.DialogInterface;
+import android.content.SharedPreferences;
+import android.preference.Preference;
 import android.preference.PreferenceActivity;
 import android.os.Bundle;
+import android.preference.PreferenceManager;
+import android.support.v7.app.AlertDialog;
+import android.widget.Toast;
 
-public class LexicaConfig extends PreferenceActivity {
+public class LexicaConfig extends PreferenceActivity implements Preference.OnPreferenceClickListener {
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
        	super.onCreate(savedInstanceState);
 		addPreferencesFromResource(R.xml.preferences);
+        findPreference("resetScores").setOnPreferenceClickListener(this);
     }
 
+    @Override
+    public boolean onPreferenceClick(Preference preference) {
+        if ("resetScores".equals(preference.getKey())) {
+            new AlertDialog.Builder(this)
+                    .setTitle(getString(R.string.pref_resetScores))
+                    .setMessage(getString(R.string.reset_scores_prompt))
+                    .setPositiveButton(android.R.string.ok, promptListener)
+                    .setNegativeButton(android.R.string.cancel, promptListener)
+                    .create().show();
+            return true;
+        }
+        return false;
+    }
+
+    private DialogInterface.OnClickListener promptListener = new DialogInterface.OnClickListener() {
+        @Override
+        public void onClick(DialogInterface dialog, int which) {
+            if (which == DialogInterface.BUTTON_POSITIVE) {
+                clearHighScores();
+            }
+        }
+    };
+
+    private void clearHighScores() {
+        SharedPreferences.Editor edit = PreferenceManager.getDefaultSharedPreferences(this).edit();
+        for (String a : getResources().getStringArray(R.array.dict_choices_entryvalues)) {
+            for (String b : getResources().getStringArray(R.array.board_size_choices_entryvalues)) {
+                for (String c : getResources().getStringArray(R.array.time_limit_choices_entryvalues)) {
+                    for (String d : getResources().getStringArray(R.array.score_type_choices_entryvalues)) {
+                        String key = ScoreActivity.HIGH_SCORE_PREFIX + a + b + c + d;
+                        edit.putInt(key, 0);
+                    }
+                }
+            }
+        }
+        edit.commit();
+        Toast.makeText(this, R.string.high_scores_reset, Toast.LENGTH_SHORT).show();
+    }
 }

--- a/app/src/main/java/com/serwylo/lexica/ScoreActivity.java
+++ b/app/src/main/java/com/serwylo/lexica/ScoreActivity.java
@@ -48,7 +48,7 @@ public class ScoreActivity extends TabActivity {
 	private static final String TAG = "ScoreActivity";
 
 	public static final String DEFINE_URL = "http://www.google.com/search?q=define%3a+";
-	public static final String HIGH_SCORE_PREFIX = "highScore";
+	public static final String SCORE_PREF_FILE = "prefs_score_file";
 
 	private Game game;
 	private BoardView bv;
@@ -317,17 +317,17 @@ public class ScoreActivity extends TabActivity {
 		}
 	}
 
-	private static String highScoreKey(SharedPreferences prefs) {
-		return HIGH_SCORE_PREFIX
-				+ prefs.getString("dict", "US")
+	private static String highScoreKey(Context c) {
+    	SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(c);
+		return prefs.getString("dict", "US")
 				+ prefs.getString("boardSize", "16")
-				+ prefs.getString("maxTimeRemaining", "180")
-				+ prefs.getString(Game.SCORE_TYPE, Game.SCORE_WORDS);
+				+ prefs.getString(Game.SCORE_TYPE, Game.SCORE_WORDS)
+				+ prefs.getString("maxTimeRemaining", "180");
 	}
 
 	private void setHighScore(int score) {
-		SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
-		String key = highScoreKey(prefs);
+		String key = highScoreKey(this);
+		SharedPreferences prefs = getSharedPreferences(SCORE_PREF_FILE, Context.MODE_PRIVATE);
 		int highScore = prefs.getInt(key, 0);
 		if (score > highScore) {
 			SharedPreferences.Editor edit = prefs.edit();
@@ -337,8 +337,8 @@ public class ScoreActivity extends TabActivity {
 	}
 
 	public static int getHighScore(Context c) {
-		SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(c);
-		return prefs.getInt(highScoreKey(prefs), 0);
+		SharedPreferences prefs = c.getSharedPreferences(SCORE_PREF_FILE, Context.MODE_PRIVATE);
+		return prefs.getInt(highScoreKey(c), 0);
 	}
 }
 

--- a/app/src/main/java/com/serwylo/lexica/ScoreActivity.java
+++ b/app/src/main/java/com/serwylo/lexica/ScoreActivity.java
@@ -18,9 +18,12 @@
 package com.serwylo.lexica;
 
 import android.app.TabActivity;
+import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.net.Uri;
 import android.os.Bundle;
+import android.preference.PreferenceManager;
 import android.util.Log;
 import android.view.Gravity;
 import android.view.LayoutInflater;
@@ -45,6 +48,7 @@ public class ScoreActivity extends TabActivity {
 	private static final String TAG = "ScoreActivity";
 
 	public static final String DEFINE_URL = "http://www.google.com/search?q=define%3a+";
+	public static final String HIGH_SCORE_PREFIX = "highScore";
 
 	private Game game;
 	private BoardView bv;
@@ -99,7 +103,9 @@ public class ScoreActivity extends TabActivity {
 
 			possible.remove(w);
 		}
-	
+
+		setHighScore(score);
+
 		max_score = score;
 		li = possible.iterator();
 
@@ -311,5 +317,28 @@ public class ScoreActivity extends TabActivity {
 		}
 	}
 
+	private static String highScoreKey(SharedPreferences prefs) {
+		return HIGH_SCORE_PREFIX
+				+ prefs.getString("dict", "US")
+				+ prefs.getString("boardSize", "16")
+				+ prefs.getString("maxTimeRemaining", "180")
+				+ prefs.getString(Game.SCORE_TYPE, Game.SCORE_WORDS);
+	}
+
+	private void setHighScore(int score) {
+		SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
+		String key = highScoreKey(prefs);
+		int highScore = prefs.getInt(key, 0);
+		if (score > highScore) {
+			SharedPreferences.Editor edit = prefs.edit();
+			edit.putInt(key, score);
+			edit.commit();
+		}
+	}
+
+	public static int getHighScore(Context c) {
+		SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(c);
+		return prefs.getInt(highScoreKey(prefs), 0);
+	}
 }
 

--- a/app/src/main/java/com/serwylo/lexica/view/LexicaLogo.java
+++ b/app/src/main/java/com/serwylo/lexica/view/LexicaLogo.java
@@ -18,6 +18,7 @@
 package com.serwylo.lexica.view;
 
 import android.annotation.TargetApi;
+import android.app.Activity;
 import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Paint;
@@ -26,6 +27,7 @@ import android.graphics.Rect;
 import android.graphics.Typeface;
 import android.os.Build;
 import android.util.AttributeSet;
+import android.util.DisplayMetrics;
 import android.view.View;
 
 import com.serwylo.lexica.R;
@@ -110,7 +112,12 @@ public class LexicaLogo extends View {
 		int height = getHeight();
 		int width = getWidth();
 
-		int size = Math.min(height,width) / 8;
+		DisplayMetrics displayMetrics = new DisplayMetrics();
+		((Activity)getContext()).getWindowManager().getDefaultDisplay().getMetrics(displayMetrics);
+		int deviceHeight = displayMetrics.heightPixels;
+		int deviceWidth = displayMetrics.widthPixels;
+
+		int size = Math.min(deviceHeight,deviceWidth) / 8;
 		p.setTextSize(size*8/10);
 
 		// Find vertical center offset
@@ -131,7 +138,7 @@ public class LexicaLogo extends View {
 		int outerPadding = paddingSize * 2;
 		int totalInnerPadding = paddingSize * 5;
 
-		size = (Math.min(height,width) - outerPadding - totalInnerPadding ) / 6;
+		size = (Math.min(deviceHeight,deviceWidth) - outerPadding - totalInnerPadding ) / 6;
 		p.setTextSize(size*8/10);
 
 		// Find vertical center offset

--- a/app/src/main/res/layout-land/splash.xml
+++ b/app/src/main/res/layout-land/splash.xml
@@ -5,13 +5,22 @@
 	android:orientation="vertical"
 	android:background="@color/background"
     >
-	
+
 	<com.serwylo.lexica.view.LexicaLogo
 		android:layout_width="fill_parent"
 		android:layout_height="0dp"
 		android:layout_weight="1.0"
 	/>
-	
+
+	<TextView
+		android:layout_width="match_parent"
+		android:layout_height="wrap_content"
+		android:gravity="center"
+		android:textSize="@dimen/textSizeLarge"
+		android:text="@string/high_score"
+		android:id="@+id/high_score"
+		/>
+
 	<LinearLayout
 		android:orientation="horizontal"
 		android:layout_width="fill_parent"
@@ -29,25 +38,19 @@
 			android:text="@string/restore_game"
 			android:enabled="false"
 			android:layout_weight="1"
-		/>
-	</LinearLayout>
-	<LinearLayout
-		android:orientation="horizontal"
-		android:layout_width="fill_parent"
-		android:layout_height="wrap_content"
-		>
-			<Button android:id="@+id/preferences"
-				android:layout_width="fill_parent"
-				android:layout_height="wrap_content"
-				android:text="@string/prefs"
-				android:layout_weight="1"
-				/>
-			<Button android:id="@+id/about"
-				android:layout_width="fill_parent"
-				android:layout_height="wrap_content"
-				android:text="@string/about"
-				android:layout_weight="1"
 			/>
+		<Button android:id="@+id/preferences"
+			android:layout_width="fill_parent"
+			android:layout_height="wrap_content"
+			android:text="@string/prefs"
+			android:layout_weight="1"
+			/>
+		<Button android:id="@+id/about"
+			android:layout_width="fill_parent"
+			android:layout_height="wrap_content"
+			android:text="@string/about"
+			android:layout_weight="1"
+		/>
 	</LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/layout-land/splash.xml
+++ b/app/src/main/res/layout-land/splash.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+	xmlns:tools="http://schemas.android.com/tools"
+
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
 	android:orientation="vertical"
@@ -17,7 +19,7 @@
 		android:layout_height="wrap_content"
 		android:gravity="center"
 		android:textSize="@dimen/textSizeLarge"
-		android:text="@string/high_score"
+		tools:text="@string/high_score"
 		android:id="@+id/high_score"
 		/>
 

--- a/app/src/main/res/layout-port/splash.xml
+++ b/app/src/main/res/layout-port/splash.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+	xmlns:tools="http://schemas.android.com/tools"
+
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
 	android:orientation="vertical"
 	android:background="@color/background"
     >
-	
+
 	<com.serwylo.lexica.view.LexicaLogo
 		android:layout_width="fill_parent"
 		android:layout_height="0dp"
@@ -17,7 +19,7 @@
 		android:layout_height="wrap_content"
 		android:gravity="center"
 		android:textSize="@dimen/textSizeLarge"
-		android:text="@string/high_score"
+		tools:text="@string/high_score"
 		android:id="@+id/high_score"
 		/>
 

--- a/app/src/main/res/layout-port/splash.xml
+++ b/app/src/main/res/layout-port/splash.xml
@@ -12,6 +12,15 @@
 		android:layout_weight="1.0"
 	/>
 
+	<TextView
+		android:layout_width="match_parent"
+		android:layout_height="wrap_content"
+		android:gravity="center"
+		android:textSize="@dimen/textSizeLarge"
+		android:text="@string/high_score"
+		android:id="@+id/high_score"
+		/>
+
 	<LinearLayout
 		android:orientation="horizontal"
 		android:layout_width="fill_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -74,4 +74,10 @@
 	<string name="total_words">Total Words:</string>
 	<string name="total_score">Total Score:</string>
 	<string name="value_max_percentage">%1$d/%2$d (%3$d%%)</string>
+
+	<string name="high_score">High Score: %d</string>
+	<string name="pref_resetScores_summary">High scores are tracked for each combination of the above settings. Tap to reset all scores to zero.</string>
+	<string name="pref_resetScores">Reset High Scores</string>
+    <string name="high_scores_reset">High scores have been reset.</string>
+	<string name="reset_scores_prompt">Are you sure you want to reset all high scores for all game modes to zero?</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -75,7 +75,7 @@
 	<string name="total_score">Total Score:</string>
 	<string name="value_max_percentage">%1$d/%2$d (%3$d%%)</string>
 
-	<string name="high_score">High Score: %d</string>
+	<string name="high_score">High Score: %1$d</string>
 	<string name="pref_resetScores_summary">High scores are tracked for each combination of the above settings. Tap to reset all scores to zero.</string>
 	<string name="pref_resetScores">Reset High Scores</string>
     <string name="high_scores_reset">High scores have been reset.</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -39,6 +39,12 @@
 		android:dialogTitle="@string/pref_scoreType_dialog"
 	/>
 
+	<PreferenceScreen
+		android:key="resetScores"
+		android:title="@string/pref_resetScores"
+		android:summary="@string/pref_resetScores_summary"
+	/>
+
 	<CheckBoxPreference
 		android:key="soundsEnabled"
 		android:title="@string/pref_sounds"


### PR DESCRIPTION
* A high score may be saved for each unique combination of dictionary, board size, time limit, and scoring type
* The current combination's high score displays on the splash screen
* High scores can be reset in the preferences menu with a prompt
* Ensure that splash tiles are the same size in portrait and landscape modes
* Put splash buttons in one row in landscape mode.