### PR TITLE
Fix word length breakdown counts

### DIFF
--- a/app/src/main/java/com/serwylo/lexica/game/Game.java
+++ b/app/src/main/java/com/serwylo/lexica/game/Game.java
@@ -271,15 +271,14 @@ public class Game implements Synchronizer.Counter {
 					ukDict);
 
 			solutions = dict.solver(board,new WordFilter() {
-				//Every word goes through the filter, so do double duty and init maxWordCountsByLength
 				public boolean isWord(String w) {
-					if (w.length() >= minWordLength) {
-						maxWordCountsByLength.put(w.length(), maxWordCountsByLength.get(w.length()) + 1);
-						return true;
-					}
-					return false;
+					return w.length() >= minWordLength;
 				}
 			});
+
+			for (String w: solutions.keySet()) {
+				maxWordCountsByLength.put(w.length(), maxWordCountsByLength.get(w.length()) + 1);
+			}
 		} catch(IOException e) {
 			// Log.e(TAG,"initializeDictionary",e);
 		}


### PR DESCRIPTION
The comment "Every word goes through the filter ..." was incorrect.
Every *solution* goes through the filter, so words with multiple
solutions were being counted too many times.