### PR TITLE
Updated grade to version 4.8.1

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Apr 09 08:55:13 AEST 2017
+#Thu Jun 21 21:41:33 CEST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.8.1-all.zip


### PR DESCRIPTION
Hello @pserwylo 

Grade version is updated to the latest version, because the version 3.3 can not determine the java version. The error message is the following:

FAILURE: Build failed with an exception.
* What went wrong:
Could not determine java version from '10.0.1'.
