### PR TITLE
Tweak tile weights

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,9 @@ jdk: oraclejdk8
 android:
   components:
     - tools
-    - build-tools-28.0.3
+    - build-tools-25.0.2
     - android-23
     - extra-android-m2repository
-    - extra-google-m2repository
 
 script:
   - ./gradlew buildDictionaries build

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,13 +2,11 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion '28.0.3'
+    buildToolsVersion '25.0.2'
 
     defaultConfig {
         applicationId "com.serwylo.lexica"
         testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
-        minSdkVersion 8
-        targetSdkVersion 23
     }
 
     lintOptions {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,11 @@
           android:versionCode="1105"
           android:versionName="0.11.5">
 
+    <uses-sdk
+        android:minSdkVersion="8"
+        android:targetSdkVersion="23"
+        />
+
     <application android:icon="@mipmap/ic_launcher" android:label="@string/app_name" android:theme="@style/AppTheme" android:allowBackup="true">
         <activity android:name=".Lexica">
             <intent-filter>

--- a/app/src/main/java/com/serwylo/lexica/game/Game.java
+++ b/app/src/main/java/com/serwylo/lexica/game/Game.java
@@ -51,7 +51,7 @@ import java.util.Map;
 public class Game implements Synchronizer.Counter {
 
 	public static final String SHOW_BREAKDOWN = "showBreakdown";
-	public static final String TILE_WEIGHT = "tileWeight";
+	public static final String HINT_MODE = "hintMode";
 	public static final String SCORE_TYPE = "scoreType";
 	public static final String SCORE_WORDS = "W";
 	public static final String SCORE_LETTERS = "L";
@@ -66,7 +66,7 @@ public class Game implements Synchronizer.Counter {
 	private int score;
 	private String scoreType;
 	private boolean showBreakdown;
-	private String tileWeight;
+	private String hintMode;
 
 	public enum GameStatus { GAME_STARTING, GAME_RUNNING, GAME_PAUSED, GAME_FINISHED }
 
@@ -344,7 +344,7 @@ public class Game implements Synchronizer.Counter {
 		}
 		scoreType = prefs.getString(SCORE_TYPE, SCORE_WORDS);
 		showBreakdown = prefs.getBoolean(SHOW_BREAKDOWN, false);
-		tileWeight = prefs.getString(TILE_WEIGHT, "tile_none");
+		hintMode = prefs.getString(HINT_MODE, "hint_none");
 	}
 
 	public void initializeDictionary() {
@@ -541,12 +541,12 @@ public class Game implements Synchronizer.Counter {
 		}
 	}
 
-	public boolean tileWeightCount() {
-		return tileWeight.equals("tile_count") || tileWeight.equals("tile_both");
+	public boolean hintModeCount() {
+		return hintMode.equals("tile_count") || hintMode.equals("hint_both");
 	}
 
-	public boolean tileWeightColor() {
-		return tileWeight.equals("tile_color") || tileWeight.equals("tile_both");
+	public boolean hintModeColor() {
+		return hintMode.equals("hint_colour") || hintMode.equals("hint_both");
 	}
 
 	public SparseIntArray getMaxWordCountsByLength() {

--- a/app/src/main/java/com/serwylo/lexica/view/LexicaView.java
+++ b/app/src/main/java/com/serwylo/lexica/view/LexicaView.java
@@ -125,7 +125,7 @@ public class LexicaView extends View implements Synchronizer.Event, Game.RotateH
 			if (highlighted.contains(i)) {
 				p.setARGB(255, 255, 255, 0);
 			} else {
-				if (game.tileWeightColor()) {
+				if (game.hintModeColor()) {
 					int[] rgb = game.getWeightColor(weight);
 					p.setARGB(255, rgb[0], rgb[1], rgb[2]);
 				} else {
@@ -167,14 +167,14 @@ public class LexicaView extends View implements Synchronizer.Event, Game.RotateH
 				int pos = game.getBoard().getRotatedPosition(y * boardWidth + x);
 				int weight = game.getWeight(pos);
 
-				if (game.tileWeightColor() || game.tileWeightCount()) {
+				if (game.hintModeColor() || game.hintModeCount()) {
 					int color = (weight == 0) ? 150 : 0;
 					p.setARGB(255, color, color, color);
 				} else {
 					p.setARGB(255, 0, 0, 0);
 				}
 
-				if (game.tileWeightCount()) {
+				if (game.hintModeCount()) {
 					p.setTextSize(textSize / 4);
 					p.setTextAlign(Paint.Align.LEFT);
 					canvas.drawText(""+weight,

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -67,17 +67,17 @@
 		<item>1800</item>
 	</string-array>
 
-	<string-array name="tile_weight_choices_entries">
-		<item>@string/tile_none</item>
+	<string-array name="hint_mode_choices_entries">
+		<item>@string/hint_none</item>
 		<item>@string/tile_count</item>
-		<item>@string/tile_color</item>
-		<item>@string/tile_both</item>
+		<item>@string/hint_colour</item>
+		<item>@string/hint_both</item>
 	</string-array>
-	<string-array name="tile_weight_choices_entryvalues">
-		<item>tile_none</item>
+	<string-array name="hint_mode_choices_entryvalues">
+		<item>hint_none</item>
 		<item>tile_count</item>
-		<item>tile_color</item>
-		<item>tile_both</item>
+		<item>hint_colour</item>
+		<item>hint_both</item>
 	</string-array>
 
 	<string-array name="definition_provider_choices_entries">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,13 +42,13 @@
 	<string name="word_length">Word Length</string>
 	<string name="letter_points">Letter Points</string>
 
-	<string name="pref_tileWeight">Tile Weight</string>
-	<string name="pref_tileWeight_summary">Select a tile weight type</string>
-	<string name="pref_tileWeight_dialog">Select Tile Weight Type</string>
-	<string name="tile_none">Show none</string>
-	<string name="tile_count">Show count</string>
-	<string name="tile_color">Show color</string>
-	<string name="tile_both">Show both</string>
+	<string name="pref_hintMode">Hint mode</string>
+	<string name="pref_hintMode_summary">Shows the number of words each letter can be used in</string>
+	<string name="pref_hintMode_dialog">Hint mode</string>
+	<string name="hint_none">Disabled</string>
+	<string name="tile_count">Number of words</string>
+	<string name="hint_colour">Tile colour</string>
+	<string name="hint_both">Both</string>
 
 	<string name="pref_sounds">Sounds Enabled</string>
 	<string name="pref_sounds_summary">Whether or not sound effects are enabled</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -57,15 +57,13 @@
 	/>
 
 	<ListPreference
-		android:key="tileWeight"
-		android:title="@string/pref_tileWeight"
-		android:summary="@string/pref_tileWeight_summary"
-		android:entries="@array/tile_weight_choices_entries"
-		android:entryValues="@array/tile_weight_choices_entryvalues"
-		android:defaultValue="tile_none"
-		android:dialogTitle="@string/pref_tileWeight_dialog"
-		/>
-
+		android:defaultValue="hint_none"
+		android:dialogTitle="@string/pref_hintMode_dialog"
+		android:entries="@array/hint_mode_choices_entries"
+		android:entryValues="@array/hint_mode_choices_entryvalues"
+		android:key="hintMode"
+		android:summary="@string/pref_hintMode_summary"
+		android:title="@string/pref_hintMode" />
 	<CheckBoxPreference
 		android:key="soundsEnabled"
 		android:title="@string/pref_sounds"

--- a/app/src/test/java/com/serwylo/lexica/FullUsGbTrieTest.java
+++ b/app/src/test/java/com/serwylo/lexica/FullUsGbTrieTest.java
@@ -19,7 +19,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;

--- a/build.gradle
+++ b/build.gradle
@@ -3,17 +3,15 @@ apply plugin: 'java'
 
 buildscript {
     repositories {
-        google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.1'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 
 allprojects {
     repositories {
-        google()
         jcenter()
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Feb 20 15:26:29 CST 2019
+#Thu Jun 21 21:41:33 CEST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.8.1-all.zip


### PR DESCRIPTION
Drop the build tool changes introduced while adding "Tile weights". I'd prefer to have this in a separate release when there is a reason to do so, otherwise it will increase the testing burden prior to release.. Also rename tile weights to "hint mode".