### PR TITLE
The Google repository is required for building

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        google()
     }
 }
 


### PR DESCRIPTION
The Google repository is required as Lexica uses the Google Maven repository.

**Errors in Android Studio when not using the Google repository:**
```
ERROR: Failed to resolve: com.android.support.test.espresso:espresso-core:2.2.2
Add Google Maven repository and sync project
Show in Project Structure dialog
Affected Modules: app


ERROR: Failed to resolve: com.android.support:appcompat-v7:23.1.1
Add Google Maven repository and sync project
Show in Project Structure dialog
Affected Modules: app


ERROR: Failed to resolve: com.android.support:support-annotations:23.1.1
Add Google Maven repository and sync project
Show in Project Structure dialog
Affected Modules: app
```

A alternative that you must use if you use a Gradle version lower than 4.1 is
```
maven {
            url "https://maven.google.com"
        }
```

But i ignored adding that because adding support for depracated Gradle versions is in my opinion useless.