### PR TITLE
Default to Android system language dictionary

### DIFF
--- a/app/src/main/java/com/serwylo/lexica/LexicaConfig.java
+++ b/app/src/main/java/com/serwylo/lexica/LexicaConfig.java
@@ -36,6 +36,22 @@ public class LexicaConfig extends PreferenceActivity implements Preference.OnPre
 		addPreferencesFromResource(R.xml.preferences);
         findPreference("resetScores").setOnPreferenceClickListener(this);
         highlightBetaLanguages();
+        setDefaultToDeviceLanguage();
+    }
+
+    private void setDefaultToDeviceLanguage() {
+        ListPreference pref = (ListPreference) findPreference("dict");
+        CharSequence[] entries = pref.getEntries();
+        CharSequence[] values = pref.getEntryValues();
+        for (int i = 0; i < entries.length; i ++) {
+            Language language = Language.fromOrNull(values[i].toString());
+            if (language != null) {
+                if (language.getLocale() == getResources().getConfiguration().locale) {
+                    pref.setDefaultValue(entries[i]);
+                    return;
+                }
+            }
+        }
     }
 
     private void highlightBetaLanguages() {

--- a/app/src/main/java/com/serwylo/lexica/LexicaConfig.java
+++ b/app/src/main/java/com/serwylo/lexica/LexicaConfig.java
@@ -36,22 +36,7 @@ public class LexicaConfig extends PreferenceActivity implements Preference.OnPre
 		addPreferencesFromResource(R.xml.preferences);
         findPreference("resetScores").setOnPreferenceClickListener(this);
         highlightBetaLanguages();
-        setDefaultToDeviceLanguage();
-    }
-
-    private void setDefaultToDeviceLanguage() {
-        ListPreference pref = (ListPreference) findPreference("dict");
-        CharSequence[] entries = pref.getEntries();
-        CharSequence[] values = pref.getEntryValues();
-        for (int i = 0; i < entries.length; i ++) {
-            Language language = Language.fromOrNull(values[i].toString());
-            if (language != null) {
-                if (language.getLocale() == getResources().getConfiguration().locale) {
-                    pref.setDefaultValue(entries[i]);
-                    return;
-                }
-            }
-        }
+        setUsedLexicon();
     }
 
     private void highlightBetaLanguages() {
@@ -67,6 +52,11 @@ public class LexicaConfig extends PreferenceActivity implements Preference.OnPre
             }
         }
         pref.setEntries(entries);
+    }
+
+    private void setUsedLexicon() {
+        ListPreference pref = (ListPreference) findPreference("dict");
+        pref.setValue(new Util().getLexiconString(this));
     }
 
     @Override

--- a/app/src/main/java/com/serwylo/lexica/Util.java
+++ b/app/src/main/java/com/serwylo/lexica/Util.java
@@ -1,0 +1,40 @@
+package com.serwylo.lexica;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+import android.util.Log;
+
+import com.serwylo.lexica.lang.Language;
+
+public class Util {
+    private static final String TAG = "Util";
+
+    public String getLexiconString(Context context) {
+        // Default to the language explicitly chosen by the user
+        SharedPreferences prefs =
+                PreferenceManager.getDefaultSharedPreferences(context);
+        String chosenLanguage = prefs.getString("dict", null);
+
+        if (chosenLanguage != null) {
+            Log.d(TAG, "User explicitly chose " + chosenLanguage);
+            return chosenLanguage;
+        }
+
+        String systemLanguage = context.getResources().getConfiguration().locale.getLanguage();
+        String[] dictionaryLanguages = context.getResources().getStringArray(R.array.dict_choices_entryvalues);
+        for (int i = 0; i < dictionaryLanguages.length; i ++) {
+            Language language = Language.fromOrNull(dictionaryLanguages[i]);
+            if (language != null) {
+                if (systemLanguage == language.getLocale().getLanguage()) {
+                    Log.d(TAG, "Language " + dictionaryLanguages[i] + " best matches " + systemLanguage);
+                    return dictionaryLanguages[i];
+                }
+            }
+        }
+
+        // Default
+        Log.d(TAG, "Could not detect language for system language " + systemLanguage + ", defaulting to US");
+        return "US";
+    }
+}

--- a/app/src/main/java/com/serwylo/lexica/game/Game.java
+++ b/app/src/main/java/com/serwylo/lexica/game/Game.java
@@ -29,6 +29,7 @@ import android.util.SparseIntArray;
 import com.serwylo.lexica.GameSaver;
 import com.serwylo.lexica.R;
 import com.serwylo.lexica.Synchronizer;
+import com.serwylo.lexica.Util;
 import com.serwylo.lexica.lang.Language;
 import com.serwylo.lexica.lang.EnglishGB;
 import com.serwylo.lexica.lang.EnglishUS;
@@ -306,7 +307,7 @@ public class Game implements Synchronizer.Counter {
 		SharedPreferences prefs =
 			PreferenceManager.getDefaultSharedPreferences(c);
 
-		String languageCode = prefs.getString("dict", "US");
+		String languageCode = new Util().getLexiconString(context);
 		language = Language.fromOrNull(languageCode);
 		if (language == null) {
 			// Legacy preferences, which use either "US" or "UK" rather than the locale name (i.e. "en_US" or "en_GB")

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -9,7 +9,6 @@
 		android:summary="@string/pref_dict_summary"
 		android:entries="@array/dict_choices_entries"
 		android:entryValues="@array/dict_choices_entryvalues"
-		android:defaultValue="US"
 		android:dialogTitle="@string/pref_dict_dialog"
 	/>
 


### PR DESCRIPTION
Fixes #138 

The main issue is that if the preferences screen is ever opened, the language is written to the SharedPreferences and thus locked and won't update automatically based on device language changes anymore. Because the user never chose a language, I consider this a bug, but most users will probably never change their device language. It just means that existing users will have to manually change their language if they ever opened the preferences screen before.