### PR TITLE
Use appropriate hint mode colours for dark theme.

### DIFF
--- a/app/src/main/res/values/colours.xml
+++ b/app/src/main/res/values/colours.xml
@@ -9,6 +9,12 @@
     <color name="gradient_yellow_to_red_1">#fee289</color>
     <color name="gradient_yellow_to_red_0">#fffcc5</color>
 
+    <color name="gradient_dark_red_4">#67000d</color>
+    <color name="gradient_dark_red_3">#a50f15</color>
+    <color name="gradient_dark_red_2">#cb181d</color>
+    <color name="gradient_dark_red_1">#ef3b2c</color>
+    <color name="gradient_dark_red_0">#fb6a4a</color>
+
     <color name="grey_0">#201F1F</color>
     <color name="grey_1">#3d3c3b</color>
     <color name="grey_2">#413f3b</color>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -19,11 +19,11 @@
         <item name="board__tile__highlight_colour">@color/orange_2</item>
         <item name="board__has_outer_border">true</item>
 
-        <item name="board__hint_mode_colour_0">@color/gradient_yellow_to_red_0</item>
-        <item name="board__hint_mode_colour_1">@color/gradient_yellow_to_red_1</item>
-        <item name="board__hint_mode_colour_2">@color/gradient_yellow_to_red_2</item>
-        <item name="board__hint_mode_colour_3">@color/gradient_yellow_to_red_3</item>
-        <item name="board__hint_mode_colour_4">@color/gradient_yellow_to_red_4</item>
+        <item name="board__hint_mode_colour_0">@color/gradient_dark_red_0</item>
+        <item name="board__hint_mode_colour_1">@color/gradient_dark_red_1</item>
+        <item name="board__hint_mode_colour_2">@color/gradient_dark_red_2</item>
+        <item name="board__hint_mode_colour_3">@color/gradient_dark_red_3</item>
+        <item name="board__hint_mode_colour_4">@color/gradient_dark_red_4</item>
         <item name="board__hint_mode_unusable_letter_colour">@color/grey_3</item>
         <item name="board__hint_mode_unusable_letter_background_colour">@color/white</item>
 


### PR DESCRIPTION
Fixes #149. Uses colours from colour brewer (colour brewer 2 swatch from #149).

**Fixed:**

![image](https://user-images.githubusercontent.com/248565/91658982-0b4fba80-eb10-11ea-8b09-f46127498ccb.png)


**Broken:**

![image](https://user-images.githubusercontent.com/248565/91658976-fbd07180-eb0f-11ea-90ad-90a1a3501ad6.png)
