### PR TITLE
Show points for selected word

### DIFF
--- a/app/src/main/java/com/serwylo/lexica/view/LexicaView.java
+++ b/app/src/main/java/com/serwylo/lexica/view/LexicaView.java
@@ -324,16 +324,19 @@ public class LexicaView extends View implements Synchronizer.Event, Game.RotateH
         // If halfway through selecting the current word, then show that.
         // Otherwise, show the last word that was selected.
         String bigWordToShow = currentWord;
-        if (bigWordToShow != null) {
-            p.setColor(theme.game.currentWordColour);
-        } else {
+        int scoreForBigWord = 0;
+        p.setColor(theme.game.currentWordColour);
+        if (bigWordToShow == null) {
             ListIterator<String> pastWords = game.listIterator();
             if (pastWords.hasNext()) {
                 String lastWord = pastWords.next();
                 if (lastWord.startsWith("+")) {
+                    p.setColor(theme.game.previouslySelectedWordColour);
                     bigWordToShow = lastWord.substring(1);
+                    scoreForBigWord = game.getWordScore(bigWordToShow);
                 } else if (game.isWord(lastWord)) {
                     bigWordToShow = lastWord;
+                    scoreForBigWord = game.getWordScore(bigWordToShow);
                 } else {
                     bigWordToShow = lastWord;
                 }
@@ -342,10 +345,12 @@ public class LexicaView extends View implements Synchronizer.Event, Game.RotateH
 
 
         if (bigWordToShow != null) {
-            p.setColor(theme.game.currentWordColour);
             p.setTextSize(theme.game.currentWordSize);
             p.setTypeface(Fonts.get().getSansSerifCondensed());
             p.setTextAlign(Paint.Align.CENTER);
+            if (scoreForBigWord > 0) {
+                bigWordToShow = isLayoutRtl() ? "+" + scoreForBigWord + " " + bigWordToShow : bigWordToShow + " +" + scoreForBigWord;
+            }
             canvas.drawText(bigWordToShow.toUpperCase(game.getLanguage().getLocale()), width / 2f, pos, p);
         }
 

--- a/app/src/main/java/com/serwylo/lexica/view/LexicaView.java
+++ b/app/src/main/java/com/serwylo/lexica/view/LexicaView.java
@@ -276,7 +276,7 @@ public class LexicaView extends View implements Synchronizer.Event, Game.RotateH
         word = word.toUpperCase(game.getLanguage().getLocale());
 
         p.setTextSize(theme.game.pastWordTextSize);
-        p.setTypeface(Fonts.get().getSansSerifBold());
+        p.setTypeface(isWord && !hasBeenUsedBefore ? Fonts.get().getSansSerifBold() : Fonts.get().getSansSerifCondensed());
         p.getTextBounds(word, 0, word.length(), textBounds);
         float height = textBounds.height();
         float width = textBounds.width();
@@ -284,7 +284,6 @@ public class LexicaView extends View implements Synchronizer.Event, Game.RotateH
         p.setColor(!isWord ? theme.game.notAWordColour : (hasBeenUsedBefore ? theme.game.previouslySelectedWordColour : theme.game.selectedWordColour));
 
         p.setTextSize(theme.game.pastWordTextSize);
-        p.setTypeface(Fonts.get().getSansSerifBold());
         p.setTextAlign(Paint.Align.LEFT);
         canvas.drawText(word, isRtl ? x - width : x, y + height, p);
 
@@ -333,13 +332,10 @@ public class LexicaView extends View implements Synchronizer.Event, Game.RotateH
                 String lastWord = pastWords.next();
                 if (lastWord.startsWith("+")) {
                     bigWordToShow = lastWord.substring(1);
-                    // p.setColor(previouslySelectedWordColour);
                 } else if (game.isWord(lastWord)) {
                     bigWordToShow = lastWord;
-                    // p.setColor(selectedWordColour);
                 } else {
                     bigWordToShow = lastWord;
-                    // p.setColor(notAWordColour);
                 }
             }
         }


### PR DESCRIPTION
Fixes #150 

Show the points for selected word, but also use a fainter colour for previously selected words.

Unsure if I've done the right thing by RTL languages or not, I use "+1 WORD" for RTL, and "WORD +1" for LTR.

![image](https://user-images.githubusercontent.com/248565/91659412-ae093880-eb12-11ea-9c1d-6268ad562269.png)
