### PR TITLE
Bump for release v1.1.0

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.serwylo.lexica"
-          android:versionCode="10000"
-          android:versionName="1.0.0">
+          android:versionCode="10100"
+          android:versionName="1.1.0">
 
     <application
 		android:icon="@mipmap/ic_launcher"

--- a/metadata/android/en-US/changelogs/10100.txt
+++ b/metadata/android/en-US/changelogs/10100.txt
@@ -1,0 +1,7 @@
+ * Entire new theme, including dark mode! (thanks elbotho for the design)
+ * Brazilian Portugese dictionary (thanks rffontenelle) 
+ * Updated translations (thanks to the numerous wonderful translators in the community)
+ * End game when all words found (thanks adam-poteralowicz)
+ * Fixed dark theme hint mode colours
+
+Please provide any feedback or report any issues on the issue tracker at https://github.com/lexica/lexica/issues.


### PR DESCRIPTION
 * End game when all words found (thanks adam-poteralowicz)
 * Fixed dark theme hint mode colours

The first one is what bumps it to a minor release. If it was just the fix to dark theme, I'd have gone v1.0.1.