### PR TITLE
Enable sponsorship via GitHub sponsors

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# These are supported funding model platforms
+
+github: [pserwylo]


### PR DESCRIPTION
Experimenting with this. In the future it would be nice to move towards other, more free and open platforms such as OpenCollective or LiberaPay, but for now this was quite straightforward to setup.