### PR TITLE
Use wiktionary to define Russian words

### DIFF
--- a/libraries/trie/src/main/java/com/serwylo/lexica/lang/Russian.java
+++ b/libraries/trie/src/main/java/com/serwylo/lexica/lang/Russian.java
@@ -79,4 +79,9 @@ public class Russian extends Language {
     protected Map<String, Integer> getLetterPoints() {
         return letterPoints;
     }
+
+    @Override
+    public String getDefinitionUrl() {
+        return "https://ru.wiktionary.org/wiki/%s";
+    }
 }


### PR DESCRIPTION
In the future, perhaps this can be the default instead of DuckDuckGo, because it
is by the Wikimedia Foundation rather than a commercial provider.

Fixes #103.