### PR TITLE
Only use greyscale colours for hint-mode in the high contrast theme.

### DIFF
--- a/app/src/main/java/com/serwylo/lexica/game/Game.java
+++ b/app/src/main/java/com/serwylo/lexica/game/Game.java
@@ -295,7 +295,7 @@ public class Game implements Synchronizer.Counter {
                 // languages without this aid. Once they go out of beta, then it seems inappropriate
                 // to print this.
                 if (language.isBeta()) {
-                    Log.d(TAG, "Word: " + word);
+                    Log.d(TAG, "Word: " + word.toUpperCase(getLanguage().getLocale()));
                 }
             }
         } catch (IOException e) {

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -23,11 +23,11 @@
         <item name="board__tile__highlight_colour">@color/grey_3</item>
         <item name="board__has_outer_border">true</item>
 
-        <item name="board__hint_mode_colour_0">@color/gradient_dark_red_0</item>
-        <item name="board__hint_mode_colour_1">@color/gradient_dark_red_1</item>
-        <item name="board__hint_mode_colour_2">@color/gradient_dark_red_2</item>
-        <item name="board__hint_mode_colour_3">@color/gradient_dark_red_3</item>
-        <item name="board__hint_mode_colour_4">@color/gradient_dark_red_4</item>
+        <item name="board__hint_mode_colour_0">@android:color/white</item>
+        <item name="board__hint_mode_colour_1">#EEE</item>
+        <item name="board__hint_mode_colour_2">#DDD</item>
+        <item name="board__hint_mode_colour_3">#CCC</item>
+        <item name="board__hint_mode_colour_4">#BBB</item>
         <item name="board__hint_mode_unusable_letter_colour">@color/grey_3</item>
         <item name="board__hint_mode_unusable_letter_background_colour">@color/white</item>
 


### PR DESCRIPTION
Although not particularly high contrast, the colours all need to be lighter than the selection
colour otherwise you wont be able to see which colour is selected.