### PR TITLE
Allow 'cancel' option when resetting high scores.

### DIFF
--- a/app/src/main/java/com/serwylo/lexica/SettingsFragment.java
+++ b/app/src/main/java/com/serwylo/lexica/SettingsFragment.java
@@ -36,7 +36,7 @@ public class SettingsFragment extends PreferenceFragmentCompat {
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
         addPreferencesFromResource(R.xml.preferences);
-        getResetCoresPreference().setOnPreferenceClickListener(preference -> promptThenResetScores());
+        getResetScoresPreference().setOnPreferenceClickListener(preference -> promptThenResetScores());
         highlightBetaLanguages();
         setUsedLexicon();
     }
@@ -57,7 +57,7 @@ public class SettingsFragment extends PreferenceFragmentCompat {
     }
 
     @NonNull
-    private Preference getResetCoresPreference() {
+    private Preference getResetScoresPreference() {
         Preference preference = findPreference("resetScores");
 
         if (preference == null) {
@@ -83,11 +83,13 @@ public class SettingsFragment extends PreferenceFragmentCompat {
     }
 
     public boolean promptThenResetScores() {
-        new AlertDialog.Builder(getContext()).setTitle(getString(R.string.pref_resetScores)).setMessage(getString(R.string.reset_scores_prompt)).setPositiveButton(android.R.string.ok, (dialog, which) -> {
-            if (which == DialogInterface.BUTTON_POSITIVE) {
-                clearHighScores();
-            }
-        }).create().show();
+        new AlertDialog.Builder(getContext())
+                .setTitle(getString(R.string.pref_resetScores))
+                .setMessage(getString(R.string.reset_scores_prompt))
+                .setPositiveButton(android.R.string.ok, (dialog, which) -> clearHighScores())
+                .setNegativeButton(android.R.string.cancel, (dialog, which) -> {})
+                .create()
+                .show();
 
         return true;
     }


### PR DESCRIPTION
Fixes #147. Prior to this, one could only click 'Ok' or click behind the modal dialog 9counterintuitively).

![image](https://user-images.githubusercontent.com/248565/92048259-952aac80-edca-11ea-97f6-019f07dcf587.png)
