### PR TITLE
Try to ensure boards with at least 45 words.

### DIFF
--- a/app/src/main/java/com/serwylo/lexica/GameActivity.java
+++ b/app/src/main/java/com/serwylo/lexica/GameActivity.java
@@ -112,7 +112,19 @@ public class GameActivity extends AppCompatActivity implements Synchronizer.Fina
     }
 
     private void newGame() {
-        game = new Game(this);
+        Game bestGame = new Game(this);
+        int numAttempts = 0;
+        while (bestGame.getMaxWordCount() < 45 && numAttempts < 5) {
+            Log.d(TAG, "Generating another board, because the previous one only had " + bestGame.getMaxWordCount() + " words, but we want at least 45. Will give up after 5 tries.");
+            Game nextAttempt = new Game(this);
+            if (nextAttempt.getMaxWordCount() > bestGame.getMaxWordCount()) {
+                bestGame = nextAttempt;
+            }
+            numAttempts ++;
+        }
+
+        Log.d(TAG, "Generated new board with " + bestGame.getMaxWordCount() + " words");
+        this.game = bestGame;
         setupGameView(game);
     }
 


### PR DESCRIPTION
Stop after 5 attempts though, because for some languages and board sizes (e.g. large Japanese boards)
it will never get many words, so just cut our losses.

Also don't try forever for performance reasons. This is a naive approach that runs on the UI thread
with no loading feedback to the user, so lets try to keep it lean on slower devices.

In the future, this would be better refactored into a different thread,
with a loading screen shown to the user.

Fixes #124.