### PR TITLE
Bump for release v1.2.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,8 +8,8 @@ android {
         applicationId "com.serwylo.lexica"
         minSdkVersion 18
         targetSdkVersion 28
-        versionCode 10100
-        versionName "1.1.0"
+        versionCode 10200
+        versionName "1.2.0"
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }

--- a/fastlane/metadata/android/en-US/changelogs/10200.txt
+++ b/fastlane/metadata/android/en-US/changelogs/10200.txt
@@ -1,0 +1,15 @@
+News:
+ * Support Lexica development via GitHub Sponsors :)
+
+Features:
+ * Sort list of words at the end of the game (thanks gsheridansmith)
+ * New Russian dictionary (thanks ildar)
+ * High contrast theme
+ * Russian words defined using wiktionary instead of DDG
+ * Prefer game boards with at least 45 words
+
+Bugfixes:
+ * Fix misaligned buttons in certain languages
+ * Add missing "cancel" option when resetting high scores
+
+Please provide any feedback or report any issues on the issue tracker at https://github.com/lexica/lexica/issues.


### PR DESCRIPTION
Phew, that was a fun few days of development. Thanks to all those in the community posting issues and proposing improvements.

Here are the release notes:

> News:
>  * Support Lexica development via GitHub Sponsors :)
> 
> Features:
>  * Sort list of words at the end of the game (thanks gsheridansmith)
>  * New Russian dictionary (thanks ildar)
>  * High contrast theme
>  * Russian words defined using wiktionary instead of DDG
>  * Prefer game boards with at least 45 words
> 
> Bugfixes:
>  * Fix misaligned buttons in certain languages
>  * Add missing "cancel" option when resetting high scores
> 
> Please provide any feedback or report any issues on the issue tracker at https://github.com/lexica/lexica/issues.
>>>