### PR TITLE
Default to Wiktionary when defining words for all languages

### DIFF
--- a/app/src/main/java/com/serwylo/lexica/activities/score/WordDefiner.java
+++ b/app/src/main/java/com/serwylo/lexica/activities/score/WordDefiner.java
@@ -25,6 +25,8 @@ public class WordDefiner {
         this.language = language;
 
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+
+        // "duckduckgo" is a legacy value which has now been re-purposed to mean "Online source".
         definitionProvider = prefs.getString("definitionProvider", "duckduckgo");
     }
 

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -103,7 +103,20 @@
 		<item>QuickDic</item>
 	</string-array>
 	<string-array name="definition_provider_choices_entryvalues">
+
+		<!--
+		Note: "duckduckgo" is a legacy from before Lexica supported multiple languages.
+		Once many languages were supported, it no longer made sense to use DuckDuckGo
+        because it defaults to English without an easy way to ask it to define in a
+        different language.
+
+        Furthermore, Wiktionary is a better option because it is more open.
+
+        Nevertheless, for legacy reasons, and because it is not worth the effort to migrate, a
+        value of "duckduckgo" means "online source" (which is most likely Witionary).
+        -->
 		<item>duckduckgo</item>
+
 		<item>aard2</item>
 		<item>quickdic</item>
 	</string-array>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -90,7 +90,7 @@
     <string name="pref_breakdown">Show Word Length Breakdown</string>
     <string name="pref_breakdown_summary">Whether or not the word count shows counts by word length</string>
     <string name="pref_definitionProvider">Definition Provider</string>
-    <string name="pref_definitionProvider_summary">Select a definition provider to use. If the selected provider is not installed, DuckDuckGo will be used.</string>
+    <string name="pref_definitionProvider_summary">Select a definition provider to use. If the selected provider is not installed, an online source such as Wiktionary will be used.</string>
     <string name="pref_definitionProvider_dialog">Select Definition Provider</string>
     <string name="pref_definitionProvider_dictionaryProvider_online">Online</string>
     <string name="pref_theme">Theme</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -78,6 +78,7 @@
 		android:summary="@string/pref_sounds_summary"
 	/>
 
+	<!-- The default value of "duckduckgo" is a legacy option which means "Online source" -->
 	<ListPreference
 		android:key="definitionProvider"
 		android:title="@string/pref_definitionProvider"

--- a/app/src/test/java/com/serwylo/lexica/FindLanguageMatchingLocale.java
+++ b/app/src/test/java/com/serwylo/lexica/FindLanguageMatchingLocale.java
@@ -98,6 +98,11 @@ public class FindLanguageMatchingLocale {
         public String applyMandatorySuffix(String value) {
             return null;
         }
+
+        @Override
+        public String getDefinitionUrl() {
+            return "";
+        }
     }
 
 }

--- a/libraries/trie/src/main/java/com/serwylo/lexica/lang/Catalan.java
+++ b/libraries/trie/src/main/java/com/serwylo/lexica/lang/Catalan.java
@@ -102,4 +102,9 @@ public class Catalan extends Language {
     protected Map<String, Integer> getLetterPoints() {
         return letterPoints;
     }
+
+    @Override
+    public String getDefinitionUrl() {
+        return getWiktionaryDefinitionUrl("ca");
+    }
 }

--- a/libraries/trie/src/main/java/com/serwylo/lexica/lang/DeGerman.java
+++ b/libraries/trie/src/main/java/com/serwylo/lexica/lang/DeGerman.java
@@ -80,4 +80,9 @@ public class DeGerman extends Language {
     protected Map<String, Integer> getLetterPoints() {
         return letterPoints;
     }
+
+    @Override
+    public String getDefinitionUrl() {
+        return getWiktionaryDefinitionUrl("de");
+    }
 }

--- a/libraries/trie/src/main/java/com/serwylo/lexica/lang/Dutch.java
+++ b/libraries/trie/src/main/java/com/serwylo/lexica/lang/Dutch.java
@@ -96,4 +96,9 @@ public class Dutch extends Language {
     protected Map<String, Integer> getLetterPoints() {
         return letterPoints;
     }
+
+    @Override
+    public String getDefinitionUrl() {
+        return getWiktionaryDefinitionUrl("nl");
+    }
 }

--- a/libraries/trie/src/main/java/com/serwylo/lexica/lang/English.java
+++ b/libraries/trie/src/main/java/com/serwylo/lexica/lang/English.java
@@ -67,4 +67,9 @@ public abstract class English extends Language {
     protected Map<String, Integer> getLetterPoints() {
         return letterPoints;
     }
+
+    @Override
+    public String getDefinitionUrl() {
+        return getWiktionaryDefinitionUrl("en");
+    }
 }

--- a/libraries/trie/src/main/java/com/serwylo/lexica/lang/French.java
+++ b/libraries/trie/src/main/java/com/serwylo/lexica/lang/French.java
@@ -84,4 +84,9 @@ public class French extends Language {
     protected Map<String, Integer> getLetterPoints() {
         return letterPoints;
     }
+
+    @Override
+    public String getDefinitionUrl() {
+        return getWiktionaryDefinitionUrl("fr");
+    }
 }

--- a/libraries/trie/src/main/java/com/serwylo/lexica/lang/Hungarian.java
+++ b/libraries/trie/src/main/java/com/serwylo/lexica/lang/Hungarian.java
@@ -80,4 +80,9 @@ public class Hungarian extends Language {
     protected Map<String, Integer> getLetterPoints() {
         return letterPoints;
     }
+
+    @Override
+    public String getDefinitionUrl() {
+        return getWiktionaryDefinitionUrl("hu");
+    }
 }

--- a/libraries/trie/src/main/java/com/serwylo/lexica/lang/Italian.java
+++ b/libraries/trie/src/main/java/com/serwylo/lexica/lang/Italian.java
@@ -91,4 +91,9 @@ public class Italian extends Language {
     protected Map<String, Integer> getLetterPoints() {
         return letterPoints;
     }
+
+    @Override
+    public String getDefinitionUrl() {
+        return getWiktionaryDefinitionUrl("it");
+    }
 }

--- a/libraries/trie/src/main/java/com/serwylo/lexica/lang/Japanese.java
+++ b/libraries/trie/src/main/java/com/serwylo/lexica/lang/Japanese.java
@@ -140,4 +140,9 @@ public class Japanese extends Language {
     protected Map<String, Integer> getLetterPoints() {
         return letterPoints;
     }
+
+    @Override
+    public String getDefinitionUrl() {
+        return getWiktionaryDefinitionUrl("ja");
+    }
 }

--- a/libraries/trie/src/main/java/com/serwylo/lexica/lang/Language.java
+++ b/libraries/trie/src/main/java/com/serwylo/lexica/lang/Language.java
@@ -131,16 +131,19 @@ public abstract class Language {
     /**
      * A URL which we can send the player to in order to define a word.
      * <p>
-     * Must include a single {@link String#format(String, Object...)} "%s" placeholder.
+     * Must include a single {@link String#format(String, Object...)} "%s" placeholder for the word
+     * to be defined.
      * <p>
-     * By default, uses DuckDuckGo, however individual languages may have their own more appropriate
-     * sources to use.
+     * Unless a specific dictionary is required for a certain language, you probably want to use the
+     * {@link Language#getWiktionaryDefinitionUrl(String)} helper method.
      * <p>
      * Note: This is only used if the "Online" dictionary provider is selected from preferences.
      * If "AARD2" or "QuickDic" is selected, they will take precedence.
      */
-    public String getDefinitionUrl() {
-        return "https://duckduckgo.com/?ia=definition&q=define+%s";
+    abstract public String getDefinitionUrl();
+
+    protected static String getWiktionaryDefinitionUrl(String langCode) {
+        return "https://" + langCode + ".wiktionary.org/wiki/%s";
     }
 
     public static class NotFound extends Exception {

--- a/libraries/trie/src/main/java/com/serwylo/lexica/lang/Persian.java
+++ b/libraries/trie/src/main/java/com/serwylo/lexica/lang/Persian.java
@@ -88,4 +88,9 @@ public class Persian extends Language {
     protected Map<String, Integer> getLetterPoints() {
         return letterPoints;
     }
+
+    @Override
+    public String getDefinitionUrl() {
+        return getWiktionaryDefinitionUrl("fa");
+    }
 }

--- a/libraries/trie/src/main/java/com/serwylo/lexica/lang/Polish.java
+++ b/libraries/trie/src/main/java/com/serwylo/lexica/lang/Polish.java
@@ -90,7 +90,7 @@ public class Polish extends Language {
 
     /**
      * The dictionary used for Polish is from https://sjp.pl, which also happens to include a
-     * definition service. Therefore, it seems appropriate to use this over DuckDuckGo.
+     * definition service. Therefore, it seems appropriate to use this over Wiktionary.
      */
     @Override
     public String getDefinitionUrl() {

--- a/libraries/trie/src/main/java/com/serwylo/lexica/lang/PortugueseBR.java
+++ b/libraries/trie/src/main/java/com/serwylo/lexica/lang/PortugueseBR.java
@@ -106,4 +106,9 @@ public class PortugueseBR extends Language {
     protected Map<String, Integer> getLetterPoints() {
         return letterPoints;
     }
+
+    @Override
+    public String getDefinitionUrl() {
+        return getWiktionaryDefinitionUrl("pt");
+    }
 }

--- a/libraries/trie/src/main/java/com/serwylo/lexica/lang/Russian.java
+++ b/libraries/trie/src/main/java/com/serwylo/lexica/lang/Russian.java
@@ -82,6 +82,6 @@ public class Russian extends Language {
 
     @Override
     public String getDefinitionUrl() {
-        return "https://ru.wiktionary.org/wiki/%s";
+        return getWiktionaryDefinitionUrl("ru");
     }
 }

--- a/libraries/trie/src/main/java/com/serwylo/lexica/lang/Spanish.java
+++ b/libraries/trie/src/main/java/com/serwylo/lexica/lang/Spanish.java
@@ -95,4 +95,9 @@ public class Spanish extends Language {
     protected Map<String, Integer> getLetterPoints() {
         return letterPoints;
     }
+
+    @Override
+    public String getDefinitionUrl() {
+        return getWiktionaryDefinitionUrl("es");
+    }
 }

--- a/libraries/trie/src/main/java/com/serwylo/lexica/lang/Ukrainian.java
+++ b/libraries/trie/src/main/java/com/serwylo/lexica/lang/Ukrainian.java
@@ -84,4 +84,13 @@ public class Ukrainian extends Language {
     protected Map<String, Integer> getLetterPoints() {
         return letterPoints;
     }
+
+    /**
+     * At time of writing, the Ukranian wiktionary only has 10,000 definitions, which may be a bit
+     * slim.
+     */
+    @Override
+    public String getDefinitionUrl() {
+        return getWiktionaryDefinitionUrl("uk");
+    }
 }


### PR DESCRIPTION
Polish doesn't use it, as Polish has a definition service that comes from the wordlist provider.

Preferable to DuckDuckGo because it is more open, and supports multiple languages.
Hopefully there is a nice offshoot that if someone tries to define a word that
doesn't exist in Wiktionary yet (e.g. Ukranian only has on the order of 10,000 words)
then players could add a definition.

Fixes #186 (doesn't use WordReference, but does use a Spanish specific version of Wiktionary).