### PR TITLE
Bump for release v1.3.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,8 +8,8 @@ android {
         applicationId "com.serwylo.lexica"
         minSdkVersion 18
         targetSdkVersion 28
-        versionCode 10200
-        versionName "1.2.0"
+        versionCode 10300
+        versionName "1.3.0"
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }

--- a/fastlane/metadata/android/en-US/changelogs/10300.txt
+++ b/fastlane/metadata/android/en-US/changelogs/10300.txt
@@ -1,0 +1,7 @@
+News:
+ * Support Lexica development via GitHub Sponsors :)
+
+Features:
+ * Use Wiktionary instead of DuckDuckGo for defintions. This enables language specific definitions, whereas previously only English definitions would work well.
+
+Please provide any feedback or report any issues on the issue tracker at https://github.com/lexica/lexica/issues.


### PR DESCRIPTION
Wiktionary for definitions, instead of DuckDuckGo.