### PR TITLE
Fix broken "analyseLanguage" tasks used for generating letter probability distributions.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ allprojects {
 
 task buildLanguageAnalysis(type: GradleBuild) {
     buildFile = file('libraries/language-analysis/build.gradle')
-    tasks = ['build']
+    tasks = ['shadowJar']
 }
 
 task buildTrieBuilder(type: GradleBuild) {
@@ -80,7 +80,7 @@ languages.each { lang ->
 
     task "analyseLanguage_${lang}"(dependsOn: [buildLanguageAnalysis, langTask], type: JavaExec) {
         main = 'com.serwylo.lexica.language.LanguageAnalysisApp'
-        classpath 'libraries/language-analysis/build/libs/language-analysis.jar'
+        classpath 'libraries/language-analysis/build/libs/language-analysis-all.jar'
         args = [
                 lang,
                 file('app/src/main/res/raw/'),

--- a/libraries/language-analysis/build.gradle
+++ b/libraries/language-analysis/build.gradle
@@ -1,4 +1,9 @@
-apply plugin: 'java'
+plugins {
+    // Used to create a fat jar with all dependencies, so that it can be executed without having to assemble the relevant dependencies on the classpath.
+    id 'com.github.johnrengelman.shadow' version '6.0.0'
+
+    id 'java'
+}
 
 dependencies {
     implementation project(':libraries:liblexica')
@@ -6,12 +11,8 @@ dependencies {
     implementation "org.apache.commons:commons-math3:3.6.1"
 }
 
-jar {
+shadowJar {
     manifest {
         attributes "Main-Class": "com.serwylo.lexica.language.LanguageAnalysisApp"
-    }
-
-    from {
-        configurations.compile.collect { it.isDirectory() ? it : zipTree(it) }
     }
 }


### PR DESCRIPTION
This was broken with an upgrade to the gradle files, whereby the 'compilation' dependencies
were replaced with 'implementation'. There are plenty of workarounds online, but the best
approach seemed to be to use a 3rd party plugin which does this for us. That should future
proof it from futher changes in the future.