### PR TITLE
Add liberapay donation option.

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,4 @@
 # These are supported funding model platforms
 
 github: [pserwylo]
+liberapay: Lexica

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Lexica: The Android Word Game
 
+[<img alt="Donate using Liberapay" src="https://liberapay.com/assets/widgets/donate.svg">](https://liberapay.com/Lexica/donate)
+
 [![Build Status](https://travis-ci.org/lexica/lexica.svg?branch=master)](https://travis-ci.org/lexica/lexica) <a href="https://hosted.weblate.org/engage/lexica/?utm_source=widget">
   <img src="https://hosted.weblate.org/widgets/lexica/-/svg-badge.svg" alt="Translation status" />
 </a>
@@ -44,8 +46,7 @@ Alternatively, you can import the project into Android Studio and build/run test
 
 This fork is based on the [original Lexic](http://code.google.com/p/lexic).
 
-So far, differences include:
- * Removed unsupported multiplayer options
- * Better support for screens with higher resolutions
- * Action bar support
- * Minor Tweaks to the UI
+Some differences include:
+ * Multiple international dictionaries and an internationalised UI.
+ * New scoring modes, hint modes, and other options.
+ * New user interface, including multiple themes.


### PR DESCRIPTION
Still a bit of an experiment to allow people who wish to donate to do so.
First attempt was GitHub sponsors, but that doesn't integrate as well with F-Droid.

Also update the readme with more details about the difference from the original lexica (a lot has changed!)