### PR TITLE
Bump for release 2.0.0-alpha1.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,14 +10,14 @@ android {
         applicationId "com.serwylo.lexica"
         minSdkVersion 18
         targetSdkVersion 28
-        versionCode 10301
-        versionName "1.3.1"
+        versionCode 20000
+        versionName "2.0.0-alpha1"
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
 
     lintOptions {
-        // The ranslations are crowd-sourced, and so will likely never be 100% complete for all locales.
+        // The translations are crowd-sourced, and so will likely never be 100% complete for all locales.
         disable 'MissingTranslation', 'GoogleAppIndexingWarning'
 
         // Due to getting the following error with Travis CI:

--- a/fastlane/metadata/android/en-US/changelogs/20000.txt
+++ b/fastlane/metadata/android/en-US/changelogs/20000.txt
@@ -1,0 +1,14 @@
+Game Modes!
+
+These preferences are replaced with "Game Modes":
+ * Duration
+ * Board size
+ * Min word length
+ * Scoring type
+ * Hint modes
+
+You can change game mode from the main screen, or create your own. High scores are based on game mode and lexicon.
+
+Please provide any feedback or report any issues on the issue tracker at https://github.com/lexica/lexica/issues.
+
+Support Lexica development via Liberapay or GitHub Sponsors :)


### PR DESCRIPTION
First alpha release, so will tag manually in F-Droid until
fdroidserver supports regex'es for non-suggested versions.