### PR TITLE
Fix min world length

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,9 +62,9 @@ dependencies {
 
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
-    implementation 'androidx.preference:preference:1.1.1'
+    implementation 'androidx.preference:preference-ktx:1.1.1'
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
-    api 'com.google.android.material:material:1.3.0-alpha03'
+    api 'com.google.android.material:material:1.3.0-beta01'
 
     // Used for buttons on the home page and elsewhere, because the default Android ones just aren't
     // quite customizable without having to go into <selectors> and such.
@@ -72,10 +72,10 @@ dependencies {
 
     implementation 'io.github.tonnyl:whatsnew:0.1.2'
 
-    implementation 'androidx.room:room-runtime:2.2.5'
-    annotationProcessor 'androidx.room:room-compiler:2.2.5'
+    implementation 'androidx.room:room-runtime:2.2.6'
+    annotationProcessor 'androidx.room:room-compiler:2.2.6'
 
-    testImplementation "junit:junit:4.13"
+    testImplementation "junit:junit:4.13.1"
     testImplementation "org.mockito:mockito-core:3.5.13"
     androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.3.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "com.serwylo.lexica"
         minSdkVersion 18
         targetSdkVersion 28
-        versionCode 20001
-        versionName "2.0.0-alpha2"
+        versionCode 20002
+        versionName "2.0.0-alpha3"
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }

--- a/app/src/main/java/com/serwylo/lexica/game/Game.java
+++ b/app/src/main/java/com/serwylo/lexica/game/Game.java
@@ -219,19 +219,6 @@ public class Game implements Synchronizer.Counter {
     public void setBoard(Board b) {
         board = b;
         boardSize = b.getSize();
-
-        switch (boardSize) {
-            case 16:
-                minWordLength = 3;
-                break;
-            case 25:
-                minWordLength = 4;
-                break;
-            case 36:
-                minWordLength = 5;
-                break;
-        }
-
         initializeDictionary();
     }
 


### PR DESCRIPTION
Correctly process min-world-length property.

Was accidentally overwriting it based on the old board-size logic immediately after reading it from the game mode.

