### PR TITLE
Fix alpha npe on startup

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "com.serwylo.lexica"
         minSdkVersion 18
         targetSdkVersion 28
-        versionCode 20001
-        versionName "2.0.0-alpha2"
+        versionCode 20002
+        versionName "2.0.0-alpha3"
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }

--- a/app/src/main/java/com/serwylo/lexica/ChooseLexiconActivity.kt
+++ b/app/src/main/java/com/serwylo/lexica/ChooseLexiconActivity.kt
@@ -36,7 +36,7 @@ class ChooseLexiconActivity : AppCompatActivity() {
     inner class Adapter : RecyclerView.Adapter<ViewHolder>() {
 
         private val languages: List<Language> = LanguageLabel.getAllLanguagesSorted(this@ChooseLexiconActivity)
-        private val selectedLanguage: Language?
+        private val selectedLanguage: Language = Util().getSelectedLanguageOrDefault(this@ChooseLexiconActivity)
 
         override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
             val binding = LexiconListItemBinding.inflate(this@ChooseLexiconActivity.layoutInflater, parent, false)
@@ -45,18 +45,13 @@ class ChooseLexiconActivity : AppCompatActivity() {
 
         override fun onBindViewHolder(holder: ViewHolder, position: Int) {
             val language = languages[position]
-            holder.bind(language, language.name == selectedLanguage?.name) { selectLexicon(language) }
+            holder.bind(language, language.name == selectedLanguage.name) { selectLexicon(language) }
         }
 
         override fun getItemCount(): Int {
             return languages.size
         }
 
-        init {
-
-            val languageCode = Util().getLexiconString(this@ChooseLexiconActivity)
-            selectedLanguage = Language.fromOrNull(languageCode)
-        }
     }
 
     private fun selectLexicon(language: Language) {

--- a/app/src/main/java/com/serwylo/lexica/MainMenuActivity.java
+++ b/app/src/main/java/com/serwylo/lexica/MainMenuActivity.java
@@ -66,8 +66,7 @@ public class MainMenuActivity extends AppCompatActivity {
         binding.gameModeButton.setOnClickListener(v -> startActivity(new Intent(this, ChooseGameModeActivity.class)));
         binding.gameModeButton.setText(gameMode.label(this));
 
-        String languageCode = new Util().getLexiconString(this);
-        Language language = Language.fromOrNull(languageCode);
+        Language language = new Util().getSelectedLanguageOrDefault(this);
         binding.languageButton.setText(LanguageLabel.getLabel(this, language));
         binding.languageButton.setOnClickListener(v -> startActivity(new Intent(this, ChooseLexiconActivity.class)));
 
@@ -112,8 +111,7 @@ public class MainMenuActivity extends AppCompatActivity {
             final Database db = Database.get(this);
             db.getOpenHelper().getReadableDatabase();
 
-            String languageCode = new Util().getLexiconString(this);
-            Language language = Language.fromOrNull(languageCode);
+            Language language = new Util().getSelectedLanguageOrDefault(this);
 
             final GameModeRepository gameModeRepository = new GameModeRepository(db.gameModeDao(), PreferenceManager.getDefaultSharedPreferences(this));
             final ResultRepository resultRepository = new ResultRepository(db.resultDao());

--- a/app/src/main/java/com/serwylo/lexica/game/Game.java
+++ b/app/src/main/java/com/serwylo/lexica/game/Game.java
@@ -238,16 +238,7 @@ public class Game implements Synchronizer.Counter {
     private void loadPreferences(Context c, GameMode gameMode) {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(c);
 
-        String languageCode = new Util().getLexiconString(context);
-        language = Language.fromOrNull(languageCode);
-        if (language == null) {
-            // Legacy preferences, which use either "US" or "UK" rather than the locale name (i.e. "en_US" or "en_GB")
-            if ("UK".equals(languageCode)) {
-                language = new EnglishGB();
-            } else {
-                language = new EnglishUS();
-            }
-        }
+        language = new Util().getSelectedLanguageOrDefault(context);
         Log.d(TAG, "Language (from preferences): " + language.getName());
 
         boardSize = gameMode.getBoardSize();

--- a/fastlane/metadata/android/en-US/changelogs/20003.txt
+++ b/fastlane/metadata/android/en-US/changelogs/20003.txt
@@ -1,0 +1,16 @@
+Game Modes!
+
+These preferences are replaced with "Game Modes":
+ * Duration
+ * Board size
+ * Min word length
+ * Scoring type
+ * Hint modes
+
+You can change game mode from the main screen, or create your own. High scores are based on game mode and lexicon.
+
+Fixed critical bug in 2.0.0-alpha2 for French and German locales (thanks to all who reported the issue).
+
+Please provide feedback/report issues at https://github.com/lexica/lexica/issues.
+
+Support Lexica development via Liberapay or GitHub Sponsors :)

--- a/libraries/trie/src/test/java/com/serwylo/lexica/lang/LanguageTest.kt
+++ b/libraries/trie/src/test/java/com/serwylo/lexica/lang/LanguageTest.kt
@@ -1,0 +1,26 @@
+package com.serwylo.lexica.lang
+
+import org.junit.Test
+
+import org.junit.Assert.*
+
+class LanguageTest {
+
+    /**
+     * Part of adding a new language means putting it in the [Language.allLanguages] map.
+     * This map requires a key to be present which matches the name of the language, as
+     * it will be used for lookups later. This ensures it is done correctly.
+     */
+    @Test
+    fun ensureLanguagesAreCorrectlyIndexed() {
+
+        Language.allLanguages.forEach {
+            val code = it.key
+            val lang = it.value
+
+            assertEquals(code, lang.name)
+        }
+
+    }
+
+}


### PR DESCRIPTION
Fix issues where devices with French and German locales will crash when trying to find a sensible default language to use for the game. 

This is due to a broken assumption that the system locale is identical to the "name" of the language in Lexica. This assumption was broken for fr + de, because there we end up with a "locale" of fr_FR or de_DE, but a "name" of fr or de. 

Changing the assumption means we really need to ensure that the `Language.allLanguages` map is correct whereby the key of the map is the same as the corresponding values "name". Therefore added a test case to assert this.

Fixes #221 