### PR TITLE
Allow consecutive sounds to play.

### DIFF
--- a/app/src/main/java/com/serwylo/lexica/game/Game.java
+++ b/app/src/main/java/com/serwylo/lexica/game/Game.java
@@ -209,8 +209,10 @@ public class Game implements Synchronizer.Counter {
 
     private void playSound(int soundId) {
         if (mSoundPool != null) {
-            int streamVolume = mgr.getStreamVolume(AudioManager.STREAM_MUSIC);
-            mSoundPool.play(soundIds[soundId], streamVolume, streamVolume, 1, 0, 1f);
+            float actualVolume = (float) mgr.getStreamVolume(AudioManager.STREAM_MUSIC);
+            float maxVolume = (float) mgr.getStreamMaxVolume(AudioManager.STREAM_MUSIC);
+            float volume = actualVolume / maxVolume;
+            mSoundPool.play(soundIds[soundId], volume, volume, 1, 0, 1f);
         }
     }
 


### PR DESCRIPTION
Based on https://stackoverflow.com/a/47123976/2391921 and other
such answers saying that the volume must be betwen 0.0 and 1.0.
In practice, the volume was a number such as 11 when testing here.

Still not sure why this broke it, but seems to work now.