### PR TITLE
Bump for release - v2.3.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "com.serwylo.lexica"
         minSdkVersion 18
         targetSdkVersion 30
-        versionCode 20009
-        versionName "2.2.1"
+        versionCode 20010
+        versionName "2.3.0"
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }

--- a/fastlane/metadata/android/en-US/changelogs/20010.txt
+++ b/fastlane/metadata/android/en-US/changelogs/20010.txt
@@ -1,0 +1,8 @@
+Multiplayer improvement:
+ * Show how many words in the board prior to inviting others or joining a game.
+ * If you prefer more or less words for your multiplayer game, you can now refresh the board prior to playing.
+
+Bug fix:
+ * Consecutive sound effects now play as expected (One of the oldest reported bugs, from 2017, thanks for the report PakoPakoJr!)
+
+Enjoy Lexica? Support further development via Liberapay or GitHub Sponsors.


### PR DESCRIPTION
Multiplayer improvement:
 * Show how many words in the board prior to inviting others or joining a game.
 * If you prefer more or less words for your multiplayer game, you can now refresh the board prior to playing.

Bug fix:
 * Consecutive sound effects now play as expected (One of the oldest reported bugs, from 2017, thanks for the report @PakoPakoJr!)

Enjoy Lexica? Support further development via Liberapay or GitHub Sponsors.
