### PR TITLE
Fix multiplayer games with "Qu"

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,7 +11,7 @@ android {
         applicationId "com.serwylo.lexica"
         minSdkVersion 18
         targetSdkVersion 30
-        versionCode 20016
+        versionCode 20017
         versionName "2.6.0"
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'

--- a/app/src/main/java/com/serwylo/lexica/share/SharedGameDataHumanReadable.kt
+++ b/app/src/main/java/com/serwylo/lexica/share/SharedGameDataHumanReadable.kt
@@ -100,8 +100,7 @@ ${Keys.minWordLength}: $minWordLength"""
         private fun extractBoard(lines: List<String>): List<String> =
             lines
                 .filter { !it.contains(":") }
-                .map { it.replace(" ", "") }
-                .map { it.toCharArray().toList().map { character -> character.toString() } }
+                .map { it.split(" ") }
                 .flatten()
 
         private fun extractMetadata(lines: List<String>): Map<String, String> =

--- a/app/src/test/java/android/util/Base64.java
+++ b/app/src/test/java/android/util/Base64.java
@@ -1,0 +1,20 @@
+package android.util;
+
+// Simplified version of Base64 for testing SharedGameData
+public class Base64 {
+	public static final int NO_PADDING = 0x1;
+	public static final int NO_WRAP = 0x2;
+	public static final int URL_SAFE = 0x8;
+
+	public static String encodeToString(byte[] input, int flags) {
+		String ret;
+		ret = java.util.Base64.getEncoder().encodeToString(input);
+		if ((flags & NO_PADDING) != 0) {
+			return ret.replace("=","");
+		}
+		return ret;
+	}
+	public static byte[] decode(String str, int flags) {
+		return java.util.Base64.getDecoder().decode(str);
+	}
+}

--- a/app/src/test/java/com/serwylo/lexica/ShareQrTest.kt
+++ b/app/src/test/java/com/serwylo/lexica/ShareQrTest.kt
@@ -10,7 +10,7 @@ import org.junit.Test
 class ShareQrTest {
 
     @Test
-    fun parseHumanReadableQr() {
+    fun parseLegacyHumanReadableQr() {
 
         val uri = Uri.parse("https://lexica.github.io/m/?b=ABCDEFGHIJKLMNOPQRSTUVWXY&l=fr_FR&t=2700&s=l&m=4&mv=20007&v=${BuildConfig.VERSION_CODE}&h=nc")
 
@@ -23,10 +23,24 @@ class ShareQrTest {
         assertEquals(4, sharedGameData.minWordLength)
         assertEquals(GameMode.SCORE_LETTERS, sharedGameData.scoreType)
         assertEquals("hint_both", sharedGameData.hints)
+    }
+
+    @Test
+    fun parseHumanReadableQr() {
+        val uri = Uri.parse("https://lexica.github.io/m/?b=QSxCLEMsRCxFLEYsRyxILEksSixLLEwsTSxOLE8sUCxRdSxSLFMsVCxVLFYsVyxYLFk&l=fr_FR&t=2700&s=l&m=4&mv=20017&v=${BuildConfig.VERSION_CODE}&h=nc")
+
+        val sharedGameData = SharedGameData.parseGame(uri)
+
+        val expectedBoard = listOf("A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Qu", "R", "S", "T", "U", "V", "W", "X", "Y")
+        assertEquals(expectedBoard, sharedGameData.board)
+        assertEquals(Language.from("fr_FR"), sharedGameData.language)
+        assertEquals(45 * 60, sharedGameData.timeLimitInSeconds)
+        assertEquals(4, sharedGameData.minWordLength)
+        assertEquals(GameMode.SCORE_LETTERS, sharedGameData.scoreType)
+        assertEquals("hint_both", sharedGameData.hints)
 
         val serialized = sharedGameData.serialize()
         assertEquals(uri, serialized)
 
     }
-
 }


### PR DESCRIPTION
As described in #256 games with "Qu" (or other multi character cells) cannot be successfully shared in multiplayer mode.

The problem is that there is no separator between the cells so the assumption is that there is a single character per cell. This change creates a separator (an underscore) so that we don't have to rely on the assumption.

The drawback is that this will break sharing with older clients (sharing from an older client is supported albeit no attempt is made to handle the "Qu" case so that will still break). Because this introduces an incompatible change I've bumped the versionCode.

A related change will be needed for the web page on https://lexica.github.io/