### PR TITLE
Bump for release v2.6.0 - Additional Spanish dictionary

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "com.serwylo.lexica"
         minSdkVersion 18
         targetSdkVersion 30
-        versionCode 20015
-        versionName "2.5.2"
+        versionCode 20016
+        versionName "2.6.0"
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }

--- a/fastlane/metadata/android/en-US/changelogs/20016.txt
+++ b/fastlane/metadata/android/en-US/changelogs/20016.txt
@@ -1,0 +1,5 @@
+Additional Spanish dictionary with Ñ but not other diacritics.
+
+Thank you very much to @jgmy for contributing this change.
+
+If you would like to add additional dictionaries for your favourite language, come join the community at http://github.com/lexica/lexica. Pull requests will be warmly received, as will issues recommending new dictionaries. 


### PR DESCRIPTION
Additional Spanish dictionary with Ñ but not other diacritics. Thanks @jgmy, I'll merge this and then tag a new release. F-Droid is [currently in the process of building v2.5.2](https://f-droid.org/wiki/index.php?title=Special:RecentChanges&days=7&from=&hidebots=0&hideanons=1&hideliu=1&limit=500). Once that is done then it will pick up this and build then release it.