### PR TITLE
Bump for release v3.0.0 - Fix multiplayer boards with Qu and Base64 encode.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "com.serwylo.lexica"
         minSdkVersion 18
         targetSdkVersion 30
-        versionCode 20017
-        versionName "2.6.0"
+        versionCode 30000
+        versionName "3.0.0"
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }

--- a/fastlane/metadata/android/en-US/changelogs/30000.txt
+++ b/fastlane/metadata/android/en-US/changelogs/30000.txt
@@ -1,0 +1,7 @@
+Better multiplayer support (thanks to ecrips):
+
+* Fixes boards containing "Qu".
+* Hides contents of the board to eager eyes when sharing via SMS.
+* WARNING: Multiplayer games from v3+ will cause older versions to crash. Upgrade to play against newer versions. Future enhancements will ask players to upgrade instead of crashing.
+
+Translations updated.


### PR DESCRIPTION
Requires a corresponding fix to the website to be released prior to merging and releasing this.