### PR TITLE
Corrected German words.

### DIFF
--- a/assets/dictionaries/dictionary.de_DE.build.sh
+++ b/assets/dictionaries/dictionary.de_DE.build.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+#Needed to have a deterministic outcome regarding the sort order. Otherwise dependant on the computer settings. 
+export LC_ALL=en_US.utf8
+
 DIR=$(dirname "$0")
 BUILD_DIR="$DIR/build"
 DICT_FILE="$DIR/dictionary.de_DE.txt"
@@ -7,19 +10,15 @@ LICENSE_FILE="$DIR/dictionary.de_DE.LICENSE"
 
 if [ -d "$BUILD_DIR" ]
 then
-    echo "Build direectory $BUILD_DIR is not empty. Please remove first."
+    echo "Build directory $BUILD_DIR is not empty. Please remove first."
     exit 1
 fi
 
 echo "Fetching German wordlist..."
 git clone --depth=1 --quiet https://github.com/enz/german-wordlist "$BUILD_DIR"
 
-echo "Lowercasing wordlist and blacklist..."
-cat "$BUILD_DIR/blacklist" | tr '[:upper:]' '[:lower:]' | sort | uniq > "$BUILD_DIR/remove"
-cat "$BUILD_DIR/words"     | tr '[:upper:]' '[:lower:]' | sort | uniq > "$BUILD_DIR/keep"
-
-echo "Removing blacklist words, loanwords, and dumping dictionary to $DICT_FILE..."
-grep --line-regexp --invert-match --file="$BUILD_DIR/remove" "$BUILD_DIR/keep" \
+echo "Correcting words (i.a. lowering) and dumping dictionary to $DICT_FILE..."
+cat "$BUILD_DIR/words" | tr '[:upper:]' '[:lower:]' | sort | uniq \
   | awk 'length($0) < 10 && length($0) > 2' \
   | grep -v -P "[àáâåÅçčéèêēëīíïîłñōóõœŒšŠūûú]" \
   | sed 's/ß/ss/g' \

--- a/assets/dictionaries/dictionary.de_DE.txt
+++ b/assets/dictionaries/dictionary.de_DE.txt
@@ -95,6 +95,7 @@ aalschnur
 aalspeer
 aalspeere
 aalspeers
+aalst
 aalstreif
 aalstrich
 aalsuppe
@@ -7272,6 +7273,7 @@ adebaren
 adebars
 adel
 adelborst
+adele
 adelest
 adelet
 adelgras
@@ -7846,6 +7848,7 @@ afrikaner
 afrikas
 afrolook
 afrolooks
+after
 afterform
 afterkind
 aftern
@@ -8159,6 +8162,7 @@ ahrweine
 ahrweinen
 ahrweines
 ahrweins
+ahs
 aibi
 aiblinger
 aichach
@@ -8586,6 +8590,7 @@ albernste
 alberst
 albert
 alberte
+alberten
 albertest
 albertet
 albes
@@ -8879,6 +8884,7 @@ allemacht
 allemal
 allemande
 allen
+aller
 allerart
 allerbest
 allergen
@@ -9125,6 +9131,7 @@ alpweiden
 alraune
 alraunen
 alrich
+als
 alsbald
 alsbaldig
 alsdann
@@ -10390,6 +10397,7 @@ andern
 änderndes
 Änderns
 anderorts
+anders
 andersen
 andersrum
 änderst
@@ -10484,6 +10492,7 @@ andrangs
 andrängst
 andrängt
 andrängte
+andre
 ändre
 andreh
 andrehe
@@ -15300,6 +15309,7 @@ apnoikern
 apnoikers
 apnoisch
 apnoische
+apo
 apodiktik
 apofonie
 apogäen
@@ -16484,6 +16494,7 @@ assel
 asseln
 assembler
 assen
+assen
 ässen
 Ässer
 Ässern
@@ -16556,6 +16567,7 @@ astats
 aste
 äste
 Äste
+asten
 ästen
 Ästen
 astend
@@ -24193,6 +24205,7 @@ balzten
 balztest
 balztet
 balzzeit
+bam
 bambara
 bamberger
 bambi
@@ -24861,6 +24874,7 @@ barockem
 barocken
 barocker
 barockere
+barockes
 barocks
 barockste
 barograf
@@ -25871,6 +25885,7 @@ bearbeit
 bearbeite
 beargwöhn
 beat
+beate
 beaten
 beatend
 beatende
@@ -33373,6 +33388,7 @@ bewusstem
 bewussten
 bewusster
 bewusstes
+bey
 beye
 beyen
 beys
@@ -33931,6 +33947,7 @@ bilchen
 bilches
 bilchmaus
 bilchs
+bild
 bildband
 bildbande
 bildbände
@@ -34201,6 +34218,7 @@ bindung
 bindungen
 bing
 binge
+bingen
 bingend
 bingens
 binger
@@ -34405,6 +34423,7 @@ birklings
 birkne
 birknem
 birknen
+birkner
 birknes
 birks
 birkvogt
@@ -37712,6 +37731,7 @@ brechnuss
 brechreiz
 brechruhr
 brechsand
+brecht
 brechung
 brechzahl
 breeches
@@ -39279,6 +39299,7 @@ bumstet
 bumsvoll
 bumsvolle
 bun
+bund
 bunda
 bundas
 bündchen
@@ -41383,6 +41404,7 @@ clusters
 clutch
 clutches
 clutchs
+cmos
 coach
 coache
 coachen
@@ -42193,6 +42215,7 @@ dabliebst
 dabliebt
 dacapo
 dacapos
+dach
 dachartig
 dachboden
 dachböden
@@ -42225,6 +42248,7 @@ dachluke
 dachluken
 dachpappe
 dachrinne
+dachs
 dachsbau
 dachsbaue
 dachsbaus
@@ -43225,6 +43249,7 @@ dattelner
 dattelns
 datum
 datums
+dau
 daube
 daubel
 daubeln
@@ -43345,6 +43370,7 @@ davysches
 dawai
 daweil
 dawider
+dax
 daytrader
 dazierin
 dazischem
@@ -45659,6 +45685,7 @@ dirndln
 dirndls
 dirne
 dirnen
+dis
 disagien
 disagio
 disagios
@@ -45827,6 +45854,7 @@ disulfit
 disulfite
 disulfits
 disziplin
+dit
 ditetrode
 dithering
 dito
@@ -48098,6 +48126,7 @@ duette
 duetten
 duettes
 duetts
+duff
 duffe
 düffel
 düffels
@@ -48950,6 +48979,7 @@ durst
 dürst
 durste
 dürste
+dursten
 dürsten
 durstend
 dürstend
@@ -49320,6 +49350,7 @@ eberesche
 ebern
 ebers
 ebit
+ebits
 ebne
 ebnem
 ebnen
@@ -49989,6 +50020,7 @@ ehrgeize
 ehrgeizen
 ehrgeizes
 ehrgeizig
+ehrlich
 ehrliche
 ehrlichem
 ehrlichen
@@ -50096,6 +50128,7 @@ eichmeter
 eichne
 eichnem
 eichnen
+eichner
 eichnes
 eichsfeld
 eichst
@@ -51868,6 +51901,7 @@ einlullet
 einlullst
 einlullt
 einlullte
+einmach
 einmache
 einmachen
 einmachet
@@ -53572,6 +53606,7 @@ eisyacht
 eiszapfen
 eiszeit
 eiszeiten
+eitel
 eitelkeit
 eitelst
 eitelste
@@ -54083,6 +54118,7 @@ elsässers
 elsasses
 elsbeeren
 elstar
+elster
 elstern
 elter
 elterlein
@@ -54170,6 +54206,7 @@ embryonen
 embryos
 emd
 emde
+emden
 emdend
 emdende
 emdendem
@@ -54752,6 +54789,7 @@ engenden
 engender
 engendes
 engens
+enger
 engere
 engerem
 engeren
@@ -54808,6 +54846,7 @@ engte
 engten
 engtest
 engtet
+enigma
 enigmas
 enigmata
 enigmen
@@ -56609,6 +56648,7 @@ epitopen
 epitops
 epitrit
 epitriten
+epo
 epochal
 epochale
 epochalem
@@ -66067,12 +66107,15 @@ fittiches
 fittichs
 fitting
 fittings
+fitz
 fitzbohne
 fitzchen
 fitzchens
+fitze
 fitzel
 fitzeln
 fitzels
+fitzen
 fitzend
 fitzende
 fitzendem
@@ -67276,6 +67319,7 @@ floristin
 flors
 floskel
 floskeln
+floss
 floss
 flöss
 flössbar
@@ -68670,7 +68714,9 @@ fossae
 fosse
 fossen
 fossil
+fossile
 fossilem
+fossilen
 fossiler
 fossiles
 fossilie
@@ -68914,6 +68960,7 @@ francium
 franciums
 franco
 francs
+frank
 frankatur
 franke
 frankem
@@ -68926,6 +68973,7 @@ frankerem
 frankeren
 frankerer
 frankeres
+frankes
 frankeste
 frankier
 frankiere
@@ -69099,6 +69147,7 @@ freewares
 freeze
 fregatte
 fregatten
+frei
 freiäugig
 freibad
 freibade
@@ -72555,6 +72604,7 @@ gauls
 gault
 gaultes
 gaults
+gaum
 gaume
 gaumen
 gaumend
@@ -84761,6 +84811,7 @@ googelt
 googelte
 googelten
 googeltet
+google
 googlest
 googlet
 googol
@@ -84857,11 +84908,13 @@ gotischer
 gotisches
 gotischs
 gotland
+gott
 gotte
 gotten
 götter
 gottergäb
 göttern
+gottes
 gotteslob
 gottfroh
 gottfrohe
@@ -86009,6 +86062,7 @@ grindwale
 grindwals
 gringo
 gringos
+grins
 grinse
 grinsen
 grinsend
@@ -86193,6 +86247,7 @@ grösserem
 grösseren
 grösserer
 grösseres
+grosses
 grosses
 grossfeuer
 grossfürst
@@ -87167,6 +87222,7 @@ gustativ
 gustative
 güste
 güstem
+güsten
 güster
 güstern
 güsters
@@ -88966,6 +89022,7 @@ hanseat
 hanseaten
 hanseatin
 hansel
+hänsel
 hänsele
 hänselei
 hänselest
@@ -89175,6 +89232,7 @@ harfte
 harften
 harftest
 harftet
+hark
 harke
 harken
 harkend
@@ -89277,6 +89335,7 @@ harpunier
 harpyie
 harpyien
 harr
+harre
 harren
 harrend
 harrende
@@ -89697,6 +89756,7 @@ hatt
 hätt
 hatte
 hätte
+hatten
 hätten
 hattest
 hättest
@@ -90058,12 +90118,14 @@ hausrats
 hausrecht
 hausrind
 hausrinds
+hauss
 haussa
 haussas
 hausschaf
 hausschuh
 hausse
 haussegen
+haussen
 haussen
 haussier
 haussiere
@@ -92052,6 +92114,7 @@ herstamm
 herstamme
 herstammt
 herstell
+herstelle
 herstellt
 hertreib
 hertreibe
@@ -93116,6 +93179,7 @@ hingab
 hingäb
 hingabe
 hingäbe
+hingaben
 hingäben
 hingäbest
 hingäbet
@@ -93912,6 +93976,7 @@ hitzkopfs
 hitzpocke
 hiv
 hivs
+hiwi
 hiwis
 hmong
 hoagascht
@@ -94235,6 +94300,7 @@ hochseils
 hochsitz
 hochsitze
 hochspiel
+höchst
 hochstamm
 hochstand
 hochstart
@@ -95996,6 +96062,8 @@ huldreich
 huldvoll
 huldvolle
 hülf
+hülfe
+hülfen
 hülfest
 hülfet
 hülfst
@@ -96872,6 +96940,7 @@ iatrogen
 iatrogene
 ibadit
 ibaditen
+iban
 iberer
 ibererin
 iberern
@@ -97155,6 +97224,7 @@ illegalen
 illegaler
 illegales
 illegitim
+iller
 illere
 illerest
 illeret
@@ -98916,6 +98986,7 @@ israeli
 israelin
 israelis
 israelit
+iss
 isst
 ist
 isthmen
@@ -99475,6 +99546,7 @@ jätetest
 jätetet
 jatwägen
 jatwinger
+jauch
 jauche
 jauchen
 jauchend
@@ -100599,6 +100671,7 @@ jurys
 jus
 juso
 jusos
+just
 justage
 justagen
 justament
@@ -101553,6 +101626,7 @@ kamelotte
 kamelotts
 kamelpost
 kamels
+kamen
 kämen
 kamens
 kamenz
@@ -101923,6 +101997,7 @@ kanonist
 kanons
 kanope
 kanopen
+kant
 kantabel
 kantabele
 kantable
@@ -105116,6 +105191,7 @@ kirgisen
 kirgisin
 kirmes
 kirmessen
+kirn
 kirne
 kirnen
 kirnend
@@ -110749,6 +110825,7 @@ krapptet
 krass
 krasse
 krassem
+krassen
 krasser
 krassere
 krasserem
@@ -110878,6 +110955,7 @@ kraulte
 kraulten
 kraultest
 kraultet
+kraus
 krause
 kräusel
 kräusele
@@ -112385,6 +112463,7 @@ kuhmist
 kuhmiste
 kuhmistes
 kuhmists
+kühn
 kühne
 kühnem
 kühnen
@@ -113185,6 +113264,7 @@ kurswägen
 kurswert
 kurswerte
 kurswerts
+kurt
 kürt
 kurtage
 kurtagen
@@ -114589,6 +114669,7 @@ lange
 länge
 längelang
 langem
+langen
 längen
 langend
 längend
@@ -114605,6 +114686,7 @@ längendes
 längenmass
 längens
 längenuhr
+langer
 länger
 längere
 längerem
@@ -115853,6 +115935,7 @@ leander
 leanders
 learjet
 learjets
+leas
 lease
 leasen
 leasend
@@ -118131,6 +118214,7 @@ lindheit
 lindne
 lindnem
 lindnen
+lindner
 lindnes
 lindre
 lindrest
@@ -119643,8 +119727,8 @@ lossagten
 lossagtet
 lossagung
 lössboden
-lössböden
 lössboden
+lössböden
 lössböden
 lössbodens
 losschick
@@ -122007,6 +122091,8 @@ malstifte
 malstifts
 malstrom
 malt
+malte
+malten
 malter
 maltern
 malters
@@ -122101,6 +122187,7 @@ mampftet
 mamsell
 mamsellen
 mamsells
+man
 mänade
 mänaden
 manag
@@ -122125,6 +122212,7 @@ manati
 manatis
 mancando
 manch
+manche
 manchem
 manchen
 mancher
@@ -123015,6 +123103,7 @@ masseln
 masselos
 masselose
 massels
+massen
 massen
 mässen
 masses
@@ -124015,6 +124104,7 @@ mehrenden
 mehrender
 mehrendes
 mehrens
+mehrer
 mehrere
 mehreren
 mehrerer
@@ -124286,6 +124376,7 @@ melismas
 melismen
 melisse
 melissen
+melk
 melke
 melkeimer
 melkem
@@ -125731,6 +125822,7 @@ minoriten
 minoritin
 minstrel
 minstrels
+mint
 minuend
 minuenden
 minus
@@ -127945,6 +128037,7 @@ morgana
 morgen
 morgenbad
 morgend
+morgende
 morgendem
 morgenden
 morgender
@@ -130742,6 +130835,7 @@ nahbaren
 nahbarer
 nahbares
 nahbrille
+nahe
 nähe
 nahebei
 nahebring
@@ -132151,6 +132245,7 @@ nesttreue
 nestwarm
 nestwarme
 nestwärme
+net
 netbook
 netbooks
 netikette
@@ -132161,6 +132256,7 @@ netphen
 nets
 netsuke
 nett
+nette
 nettem
 netten
 netter
@@ -135065,6 +135161,7 @@ oikonymen
 oikonyms
 oikos
 oiraten
+oje
 ojemine
 ojerum
 ojibwa
@@ -137188,6 +137285,7 @@ pair
 pairie
 pairien
 pairs
+pak
 paket
 paketboot
 paketbote
@@ -138228,6 +138326,7 @@ parzen
 parzipan
 parzipane
 parzipans
+pas
 pascal
 pascals
 pasch
@@ -139568,6 +139667,7 @@ perzentil
 perzents
 perzeptiv
 perzipier
+pes
 pesade
 pesaden
 pesante
@@ -141572,6 +141672,7 @@ pizzerien
 pizzicato
 pizzikati
 pizzikato
+pkw
 placebo
 placebos
 placement
@@ -142113,6 +142214,7 @@ pleinair
 pleinairs
 pleite
 pleitegeh
+pleiten
 pleitier
 pleitiers
 plejaden
@@ -143510,6 +143612,7 @@ porzinem
 porzinen
 porziner
 porzines
+pos
 posada
 posaden
 posament
@@ -147272,6 +147375,7 @@ quislinge
 quislings
 quitt
 quitte
+quitten
 quittier
 quittiere
 quittiert
@@ -147880,6 +147984,7 @@ rahmtest
 rahmtet
 rahmung
 rahmungen
+rahn
 rahne
 rahnem
 rahnen
@@ -150175,6 +150280,7 @@ redigiere
 redigiert
 redingote
 redivivus
+redlich
 redliche
 redlichem
 redlichen
@@ -150236,6 +150342,7 @@ reepe
 reepen
 reepes
 reeps
+rees
 reese
 reesen
 reesend
@@ -150557,6 +150664,7 @@ regulus
 regulusse
 regung
 regungen
+reh
 reha
 rehas
 rehbein
@@ -150863,6 +150971,7 @@ reine
 reinem
 reinemach
 reinen
+reiner
 reinerbig
 reinere
 reinerem
@@ -151895,6 +152004,7 @@ responsum
 ressort
 ressorts
 ressource
+rest
 restant
 restanten
 restantin
@@ -152628,6 +152738,7 @@ rietest
 rietet
 riets
 rietst
+rif
 riff
 riffe
 riffel
@@ -153379,6 +153490,7 @@ rogener
 rogenern
 rogeners
 rogens
+roger
 roggen
 roggens
 rogner
@@ -153674,6 +153786,7 @@ rollwerk
 rollwerke
 rollwerks
 rollzeit
+rom
 roma
 romadur
 romadurs
@@ -155832,9 +155945,11 @@ rusniaken
 rusniakin
 russ
 russe
+russe
 rüssel
 rüsseln
 rüssels
+russen
 russen
 russend
 russende
@@ -156862,6 +156977,7 @@ salzzoll
 salzzolle
 salzzölle
 salzzolls
+sam
 sämann
 sämanne
 sämänner
@@ -157776,6 +157892,7 @@ sauenden
 sauender
 sauendes
 sauens
+sauer
 säuer
 sauerbier
 sauerdorn
@@ -158472,6 +158589,7 @@ schalerem
 schaleren
 schalerer
 schaleres
+schales
 schalest
 schälest
 schalet
@@ -158647,6 +158765,7 @@ schandtat
 schändung
 schängeln
 schängels
+schanghai
 schani
 schanis
 schank
@@ -159565,7 +159684,9 @@ schilifts
 schill
 schille
 schillen
+schiller
 schillere
+schillern
 schillert
 schilles
 schilling
@@ -160566,6 +160687,7 @@ schmisses
 schmisset
 schmissig
 schmisst
+schmitz
 schmitze
 schmitzen
 schmitzes
@@ -160917,6 +161039,8 @@ schneuss
 schneusse
 schneussen
 schneusses
+schneuze
+schneuzen
 schneuzet
 schneuzte
 schnibbel
@@ -161981,6 +162105,7 @@ schult
 schultag
 schultage
 schultags
+schulte
 schulten
 schulter
 schultere
@@ -165054,6 +165179,8 @@ sichtlich
 sichtung
 sichtwort
 sick
+sicke
+sicken
 sickend
 sickende
 sickendem
@@ -168762,6 +168889,7 @@ spirkeln
 spirkels
 spirre
 spirren
+spiss
 spisse
 spissen
 spissens
@@ -171018,6 +171146,7 @@ steinbutt
 steinchen
 steindamm
 steine
+steinen
 steinend
 steinende
 steinens
@@ -173222,6 +173351,7 @@ strünke
 strünken
 strunkes
 strunks
+strunz
 strunze
 strunzen
 strunzend
@@ -173432,6 +173562,7 @@ stülpte
 stülpten
 stülptest
 stülptet
+stumm
 stumme
 stummel
 stümmel
@@ -175916,6 +176047,7 @@ taljeten
 taljetest
 taljetet
 talk
+talke
 talkend
 talkende
 talkendem
@@ -177269,6 +177401,7 @@ teddybär
 teddys
 tedeum
 tedeums
+tee
 teebaum
 teebaume
 teebäume
@@ -178144,6 +178277,7 @@ teutschen
 teutscher
 teutsches
 tewet
+tex
 texaner
 texanerin
 texanern
@@ -178782,6 +178916,8 @@ tilgtest
 tilgtet
 tilgung
 tilgungen
+till
+tille
 tillest
 tillet
 tillst
@@ -178794,6 +178930,7 @@ tilsiter
 tilsitern
 tilsiters
 tiltrotor
+tim
 timbre
 timbres
 timbrier
@@ -196180,6 +196317,7 @@ vokale
 vokalem
 vokalen
 vokaler
+vokales
 vokalisch
 vokalise
 vokalisen
@@ -196305,6 +196443,7 @@ vollender
 vollendet
 vollends
 voller
+völler
 vollere
 völlere
 völlerei
@@ -196581,6 +196720,7 @@ vonnöten
 vons
 vonseiten
 voodoo
+vopo
 vopos
 vor
 vorab
@@ -201429,6 +201569,7 @@ weihtet
 weihung
 weihungen
 weihwedel
+weil
 weiland
 weilchen
 weilchens
@@ -203175,6 +203316,7 @@ wildzaune
 wildzäune
 wildzauns
 wildziege
+will
 wille
 willen
 willenlos
@@ -203976,6 +204118,7 @@ woge
 wöge
 wogegen
 wogen
+wögen
 wogend
 wogende
 wogendem
@@ -205154,6 +205297,7 @@ wurzelten
 wurzeltet
 wurzelzog
 wurzelzög
+wurzen
 würzen
 wurzend
 würzend
@@ -205631,6 +205775,8 @@ yurumis
 yuvianuss
 zabaione
 zabaiones
+zach
+zache
 zachem
 zachen
 zacher
@@ -205694,6 +205840,7 @@ zaddikim
 zaddiks
 zafu
 zafus
+zag
 zage
 zagel
 zagele
@@ -211816,6 +211963,7 @@ zuwendest
 zuwendet
 zuwendete
 zuwendung
+zuwenig
 zuwenigs
 zuwerf
 zuwerfe


### PR DESCRIPTION
The problem was that the blacklist should not be considered as otherwise correct words are incorrectly thrown out.

This fixes #262. Maybe also see https://github.com/enz/german-wordlist/pull/8 where it is explained by the author of the German word list repository.