### PR TITLE
Improved call to Wiktionary.

### DIFF
--- a/libraries/trie/src/main/java/com/serwylo/lexica/lang/Language.kt
+++ b/libraries/trie/src/main/java/com/serwylo/lexica/lang/Language.kt
@@ -145,7 +145,7 @@ abstract class Language {
 
         @JvmStatic
         fun getWiktionaryDefinitionUrl(langCode: String): String {
-            return "https://$langCode.wiktionary.org/wiki/%s"
+            return "https://$langCode.wiktionary.org/w/index.php?search=%s"
         }
 
     }


### PR DESCRIPTION
This partially addresses the problem from #264.

The link `https://de.wiktionary.org/wiki/hunde` does not find anything as the direct link needs the correct case sensitivity = `https://de.wiktionary.org/wiki/Hunde`. Interestingly for the English Wiktionary an implicit redirect is done from the server after 1-2 seconds. See for instance `https://en.wiktionary.org/wiki/england`. This implicit redirect does not happen for the German version (no clue why they handle it differently).

The solution is to use the search function. For me this always resulted in a redirect to the first found result. So independent of the case sensitivity.

However the only caveat I could find is that Wiktionary does not only show entries for the wanted language. So `de.wiktionary` is not only German. `en.wiktionary` is not only English. However that problem would also occur with the previous used logic to call the expression directly in the URL. Like for instance `https://de.wiktionary.org/wiki/hund` behaves the same as `https://de.wiktionary.org/w/index.php?search=hund`.

I had a rough look at the Wiktionary API but I couldn't find anything regarding an explicit language parameter. Probably there is one but their API documentation quite frankly confuses me.

Furthermore I considered the suggested solution from #264. So to save the original German word list without the modifications regarding lowering and diacritics. However this would have meant that there needs to be a mapping between this list and the other 2 lists which would have resulted in a bit of an hassle. Also as proven above the other languages can also suffer from the same problem regarding case sensitivity in Wiktionary. So this solution should probably work for all of them.