### PR TITLE
Clean up the UX on the final score screen

### DIFF
--- a/app/src/main/java/com/serwylo/lexica/activities/score/ScoreActivity.kt
+++ b/app/src/main/java/com/serwylo/lexica/activities/score/ScoreActivity.kt
@@ -19,6 +19,8 @@ package com.serwylo.lexica.activities.score
 import android.content.Intent
 import android.os.Bundle
 import android.util.TypedValue
+import android.view.Menu
+import android.view.MenuItem
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import com.serwylo.lexica.GameSaverTransient
@@ -35,6 +37,8 @@ class ScoreActivity : AppCompatActivity() {
 
     private var buttonBackgroundColorSelected = 0
     private var buttonBackgroundColor = 0
+
+    private var isOnlyFoundWords = false
 
     public override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -59,6 +63,8 @@ class ScoreActivity : AppCompatActivity() {
 
         buttonBackgroundColor = themeValues.data
 
+        isOnlyFoundWords = intent.getBooleanExtra(ONLY_FOUND_WORDS, false)
+
         binding = ScoreBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
@@ -66,6 +72,12 @@ class ScoreActivity : AppCompatActivity() {
         this.game = game
 
         initialiseView(game)
+
+        setSupportActionBar(binding.toolbar)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        binding.toolbar.setNavigationOnClickListener {
+            finish()
+        }
     }
 
     private fun initialiseGame(savedInstanceState: Bundle?): Game {
@@ -83,11 +95,10 @@ class ScoreActivity : AppCompatActivity() {
         binding.recyclerView.setHasFixedSize(true)
         binding.recyclerView.adapter = ScoreTabAdapter(this, game)
 
-        val onlyFoundWords = intent.getBooleanExtra(ONLY_FOUND_WORDS, false)
-        if (onlyFoundWords) {
+        if (isOnlyFoundWords) {
             binding.foundWordsButton.visibility = View.GONE
             binding.missedWordsButton.visibility = View.GONE
-            binding.shareButton.visibility = View.GONE
+            binding.toolbar.title = getString(R.string.found_words)
         }
 
         binding.foundWordsButton.setBackgroundColor(buttonBackgroundColorSelected)
@@ -103,9 +114,6 @@ class ScoreActivity : AppCompatActivity() {
             binding.foundWordsButton.setBackgroundColor(buttonBackgroundColor)
             binding.missedWordsButton.setBackgroundColor(buttonBackgroundColorSelected)
         }
-
-        binding.backButton.setOnClickListener { finish() }
-        binding.shareButton.setOnClickListener { share() }
     }
 
     private fun share() {
@@ -125,6 +133,22 @@ class ScoreActivity : AppCompatActivity() {
         }
 
         startActivity(Intent.createChooser(sendIntent, getString(R.string.send_challenge_invite_to)))
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu?): Boolean {
+        if (!isOnlyFoundWords) {
+            menuInflater.inflate(R.menu.score_menu, binding.toolbar.menu);
+            return true
+        }
+
+        return false;
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        when (item.itemId) {
+            R.id.share -> share()
+        }
+        return true
     }
 
     override fun onSaveInstanceState(outState: Bundle) {

--- a/app/src/main/res/drawable/ic_share.xml
+++ b/app/src/main/res/drawable/ic_share.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M18,16.08c-0.76,0 -1.44,0.3 -1.96,0.77L8.91,12.7c0.05,-0.23 0.09,-0.46 0.09,-0.7s-0.04,-0.47 -0.09,-0.7l7.05,-4.11c0.54,0.5 1.25,0.81 2.04,0.81 1.66,0 3,-1.34 3,-3s-1.34,-3 -3,-3 -3,1.34 -3,3c0,0.24 0.04,0.47 0.09,0.7L8.04,9.81C7.5,9.31 6.79,9 6,9c-1.66,0 -3,1.34 -3,3s1.34,3 3,3c0.79,0 1.5,-0.31 2.04,-0.81l7.12,4.16c-0.05,0.21 -0.08,0.43 -0.08,0.65 0,1.61 1.31,2.92 2.92,2.92 1.61,0 2.92,-1.31 2.92,-2.92s-1.31,-2.92 -2.92,-2.92z"/>
+</vector>

--- a/app/src/main/res/layout/score.xml
+++ b/app/src/main/res/layout/score.xml
@@ -7,6 +7,20 @@
 	xmlns:app="http://schemas.android.com/apk/res-auto"
 	xmlns:fancy="http://schemas.android.com/apk/res-auto">
 
+	<androidx.appcompat.widget.Toolbar
+		android:layout_width="match_parent"
+		android:layout_height="wrap_content"
+		android:background="?attr/colorPrimary"
+		android:minHeight="?attr/actionBarSize"
+		android:theme="?attr/actionBarTheme"
+		app:popupTheme="?attr/actionBarPopupTheme"
+		app:layout_constraintStart_toStartOf="parent"
+		app:layout_constraintEnd_toEndOf="parent"
+		app:layout_constraintTop_toTopOf="parent"
+		android:id="@+id/toolbar"
+		app:title="@string/score"
+		/>
+
 	<androidx.recyclerview.widget.RecyclerView
 		android:id="@+id/recycler_view"
 		android:layout_width="0dp"
@@ -14,7 +28,7 @@
 		app:layout_constraintBottom_toTopOf="@+id/button_wrapper_top"
 		app:layout_constraintEnd_toEndOf="parent"
 		app:layout_constraintStart_toStartOf="parent"
-		app:layout_constraintTop_toTopOf="parent"
+		app:layout_constraintTop_toBottomOf="@id/toolbar"
 		tools:listitem="@layout/score_found_words" />
 
 	<LinearLayout
@@ -22,7 +36,7 @@
 		android:layout_width="0dp"
 		android:layout_height="wrap_content"
 		android:orientation="horizontal"
-		app:layout_constraintBottom_toTopOf="@id/button_wrapper_bottom"
+		app:layout_constraintBottom_toBottomOf="parent"
 		app:layout_constraintEnd_toEndOf="parent"
 		app:layout_constraintStart_toStartOf="parent">
 
@@ -61,55 +75,6 @@
 			fancy:fb_fontIconSize="24sp"
 			fancy:fb_iconPosition="top"
 			fancy:fb_text="@string/missed_words"
-			fancy:fb_textColor="?attr/home__secondary_button_text_colour"
-			fancy:fb_textSize="18sp" />
-
-	</LinearLayout>
-
-	<LinearLayout
-		android:id="@+id/button_wrapper_bottom"
-		android:layout_width="0dp"
-		android:layout_height="wrap_content"
-		android:orientation="horizontal"
-		app:layout_constraintBottom_toBottomOf="parent"
-		app:layout_constraintEnd_toEndOf="parent"
-		app:layout_constraintStart_toStartOf="parent">
-
-		<mehdi.sakout.fancybuttons.FancyButton
-			android:id="@+id/back_button"
-			android:layout_width="0dp"
-			android:layout_height="match_parent"
-			android:layout_weight="1"
-			android:paddingTop="?attr/home__button_padding"
-			android:paddingBottom="?attr/home__button_padding"
-			app:layout_constraintWidth_percent="0.5"
-			fancy:fb_borderWidth="2dp"
-			fancy:fb_borderColor="?attr/home__secondary_button_border"
-			fancy:fb_defaultColor="?attr/home__secondary_button_background"
-			fancy:fb_focusColor="?attr/home__secondary_button_background_focused"
-			fancy:fb_fontIconResource="&#xf0a8;"
-			fancy:fb_fontIconSize="24sp"
-			fancy:fb_iconPosition="top"
-			fancy:fb_text="@string/back"
-			fancy:fb_textColor="?attr/home__secondary_button_text_colour"
-			fancy:fb_textSize="18sp" />
-
-		<mehdi.sakout.fancybuttons.FancyButton
-			android:id="@+id/share_button"
-			android:layout_width="0dp"
-			android:layout_height="match_parent"
-			android:layout_weight="1"
-			android:paddingTop="?attr/home__button_padding"
-			android:paddingBottom="?attr/home__button_padding"
-			app:layout_constraintWidth_percent="0.5"
-			fancy:fb_borderWidth="2dp"
-			fancy:fb_borderColor="?attr/home__secondary_button_border"
-			fancy:fb_defaultColor="?attr/home__secondary_button_background"
-			fancy:fb_focusColor="?attr/home__secondary_button_background_focused"
-			fancy:fb_fontIconResource="&#xf1e0;"
-			fancy:fb_fontIconSize="24sp"
-			fancy:fb_iconPosition="top"
-			fancy:fb_text="@string/share"
 			fancy:fb_textColor="?attr/home__secondary_button_text_colour"
 			fancy:fb_textSize="18sp" />
 

--- a/app/src/main/res/menu/score_menu.xml
+++ b/app/src/main/res/menu/score_menu.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+	  xmlns:app="http://schemas.android.com/apk/res-auto">
+	<item android:id="@+id/share"
+		android:title="@string/share"
+		android:icon="@drawable/ic_share"
+		app:showAsAction="always"/>
+</menu>


### PR DESCRIPTION
Add a toolbar, remove excess buttons at the bottom of screen.

Hopefully this makes it just as easy to share, without having to worry about taking up heaps of extra space on the final screen.

Makes sure not to show the share button and to update the title of the toolbar if the activity is being used to show the current words found so far in the game.

![image](https://user-images.githubusercontent.com/248565/137119172-19861a1b-fc3f-469a-b560-367585cd3ab7.png)
