### PR TITLE
Bump for release v3.6.1 - Misc improvements

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "com.serwylo.lexica"
         minSdkVersion 18
         targetSdkVersion 30
-        versionCode 30007
-        versionName "3.6.0"
+        versionCode 30008
+        versionName "3.6.1"
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }

--- a/fastlane/metadata/android/en-US/changelogs/30008.txt
+++ b/fastlane/metadata/android/en-US/changelogs/30008.txt
@@ -1,0 +1,8 @@
+Improvements (thanks to Sjord):
+ * English (GB) wordlist: Remove words that are not present in Collins, NASPA, Tournament, or Wiktionary.
+ * Dutch dictionary: Better letter distributions for more fun games.
+
+Bug fix (thanks to OpenWarp):
+ * Multiplayer correctly opens on Android 6.0.
+
+Please provide feedback/report issues at https://github.com/lexica/lexica/issues.


### PR DESCRIPTION
Improvements (thanks to Sjord):
 * English (GB) wordlist: Remove words that are not present in Collins, NASPA, Tournament, or Wiktionary.
 * Dutch dictionary: Better letter distributions for more fun games.

Bug fix (thanks to OpenWarp):
 * Multiplayer correctly opens on Android 6.0.

Please provide feedback/report issues at https://github.com/lexica/lexica/issues.