### PR TITLE
Fix: Increase german letterpoints for 'v' from 1 to 6 according to scrabble

### DIFF
--- a/libraries/trie/src/main/java/com/serwylo/lexica/lang/GermanDe.java
+++ b/libraries/trie/src/main/java/com/serwylo/lexica/lang/GermanDe.java
@@ -39,7 +39,7 @@ public class GermanDe extends Language {
         letterPoints.put("ä", 6);
         letterPoints.put("j", 6);
         letterPoints.put("ü", 6);
-        letterPoints.put("v", 1);
+        letterPoints.put("v", 6);
 
         letterPoints.put("ö", 8);
         letterPoints.put("x", 8);

--- a/libraries/trie/src/main/java/com/serwylo/lexica/lang/GermanDeNoDiacritics.java
+++ b/libraries/trie/src/main/java/com/serwylo/lexica/lang/GermanDeNoDiacritics.java
@@ -35,7 +35,7 @@ public class GermanDeNoDiacritics extends Language {
         letterPoints.put("p", 4);
 
         letterPoints.put("j", 6);
-        letterPoints.put("v", 1);
+        letterPoints.put("v", 6);
 
         letterPoints.put("x", 8);
 


### PR DESCRIPTION
Hi, apparently due to human error, the letterpoints value for the letter v was still set to 1 for the two german modes. This PR sets it to 6, according to the german scrabble letterpoint value (see https://en.wikipedia.org/wiki/Scrabble_letter_distributions#German )