### PR TITLE
GameDetailsView compatibility with API levels < 21

### DIFF
--- a/app/src/main/java/com/serwylo/lexica/view/GameDetailsView.kt
+++ b/app/src/main/java/com/serwylo/lexica/view/GameDetailsView.kt
@@ -1,6 +1,5 @@
 package com.serwylo.lexica.view
 
-import android.annotation.SuppressLint
 import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
@@ -11,17 +10,13 @@ import com.serwylo.lexica.databinding.GameDetailsBinding
 import com.serwylo.lexica.db.GameMode
 import com.serwylo.lexica.lang.Language
 import com.serwylo.lexica.lang.LanguageLabel
-import kotlin.math.sqrt
 
-@SuppressLint("NewApi") // JVMOverloads will ensure we have non-new-API compatability.
 class GameDetailsView @JvmOverloads constructor(
-    context: Context,
-    attrs: AttributeSet? = null,
-    defStyle: Int = 0,
-    defStyleRes: Int = 0
-) : FrameLayout(context, attrs, defStyle, defStyleRes) {
-
-    private val binding = GameDetailsBinding.inflate(LayoutInflater.from(context), this, true)
+        context: Context,
+        attrs: AttributeSet? = null
+) : FrameLayout(context, attrs) {
+    private val binding = GameDetailsBinding.inflate(
+            LayoutInflater.from(context), this, true)
 
     init {
         binding.language.visibility = View.GONE
@@ -32,7 +27,7 @@ class GameDetailsView @JvmOverloads constructor(
             binding.language.visibility = View.GONE
         } else {
             binding.language.visibility = View.VISIBLE
-            binding.language.text = LanguageLabel.getLabel(context, language);
+            binding.language.text = LanguageLabel.getLabel(context, language)
         }
     }
 
@@ -52,5 +47,4 @@ class GameDetailsView @JvmOverloads constructor(
         }
 
     }
-
 }


### PR DESCRIPTION
Fixes #330.

This was introduce in 3356a6a678f555c4d247b5f5c7ee56506a90194d with the comment that @JvmOverloads ensures no-NewApi compatibility, but that is not correct: although we correctly expose the 1-args, 2-args and 3-args constructors for GameDetails view, on API levels < 21, the 4-args FrameLayout constructor we use does not exist!

According to the Android documentation, the purpose of the 4-args[^1] and 3-args[^2] constructors is to allow subclasses to use their own base style when they are inflating, but they are not called by the framework, which calls the 2-args constructor when inflating from XML[^3].

This patch changes GameDetailsView to use the 2-args constructor (with @JvmOverloads), following the reasoning outlined
[here](https://proandroiddev.com/misconception-about-kotlin-jvmoverloads-for-android-view-creation-cb88f432e1fe).

NB: This is essentially the same thing as #335 except that I used the 2-args instead of 3-args constructor, as explained above.  I wrote this patch last night and saw #335 as I was preparing to create the PR... I apologize for the duplicate work but decided that since had already written the explanation, I'd open the PR nevertheless since it can also serve as documentation for the fix in #335.

[^1]: https://developer.android.com/reference/android/view/View#View(android.content.Context,%20android.util.AttributeSet,%20int,%20int)
[^2]: https://developer.android.com/reference/android/view/View#View(android.content.Context,%20android.util.AttributeSet,%20int)
[^3]: https://developer.android.com/reference/android/view/View#View(android.content.Context,%20android.util.AttributeSet)