### PR TITLE
Fix 'Android' multiplayer links to not require internet access

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -58,19 +58,7 @@
 				<category android:name="android.intent.category.DEFAULT"/>
 				<category android:name="android.intent.category.BROWSABLE"/>
 
-				<data android:scheme="https"/>
-				<data android:host="lexica.github.io"/>
-				<data android:pathPrefix="/share/"/>
-			</intent-filter>
-
-			<intent-filter>
-				<action android:name="android.intent.action.VIEW"/>
-
-				<category android:name="android.intent.category.DEFAULT"/>
-				<category android:name="android.intent.category.BROWSABLE"/>
-
-				<data android:scheme="lexica"/>
-				<data android:host="share"/>
+				<data android:scheme="lexica" android:host="share"/>
 			</intent-filter>
 		</activity>
 

--- a/app/src/main/java/com/serwylo/lexica/share/SharedGameData.kt
+++ b/app/src/main/java/com/serwylo/lexica/share/SharedGameData.kt
@@ -102,16 +102,34 @@ data class SharedGameData(
 
         val webPath = "web-lexica/multiplayer"
 
-        val path = when (platform) {
-            Platform.WEB -> webPath
-            Platform.ANDROID -> androidPath
+        return when (platform) {
+            Platform.WEB -> {
+                val path = when (type) {
+                    Type.MULTIPLAYER, Type.SHARE -> webPath
+                }
+                Uri.Builder()
+                    .scheme("https")
+                    .authority("lexica.github.io")
+                    .path("/$path/")
+            }
+            Platform.ANDROID -> {
+                when (type) {
+                    Type.MULTIPLAYER -> {
+                        Uri.Builder()
+                            .scheme("lexica")
+                            .authority("multiplayer")
+                    }
+                    Type.SHARE -> {
+                        Uri.Builder()
+                            .scheme("https")
+                            .authority("lexica.github.io")
+                            .path("/$androidPath/")
+                    }
+                }
+            }
         }
-
-        return Uri.Builder()
-                .scheme("https")
-                .authority("lexica.github.io")
-                .path("/$path/")
     }
+
     object Keys {
         const val board = "b"
         const val language = "l"


### PR DESCRIPTION
Changes the 'https://lexica.github.io' baseurl for Android link sharing to be a 'lexica://' link so that there isn't any need to query for a Digital Asset Links JSON on the web site in order for Android to allow us to be the handler for such links.

Does rely on the behavior of the QR scanning app to correctly handle a lexica:// link embedded in the QR code; in my testing the Samsung S22 camera app handles it as expected, but a Pixel 6a didn't and instead tried to perform a web search for the URI.  If need be, we could add a camera QR scanning feature to Lexica to make it consistent.