### PR TITLE
Use JDK 11 to build API.

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-java@v1
         with:
-          java-version: 8
+          java-version: 11
 
       - name: Build API files
         run: ./gradlew :api-generator:generateApi


### PR DESCRIPTION
This is required after bumping the gradle version.

I didn't pick it up on the original change because that doesn't run the API CI until after merging to master (due to it deploying artifacts).