### PR TITLE
Fix overflowing time limit

### DIFF
--- a/app/src/main/java/com/serwylo/lexica/game/Game.java
+++ b/app/src/main/java/com/serwylo/lexica/game/Game.java
@@ -194,8 +194,8 @@ public class Game implements Synchronizer.Counter {
 
         setBoard(context, board);
 
-        timeRemainingInMillis = gameMode.getTimeLimitSeconds() * 1000;
-        maxTimeSinceResumeInMillis = gameMode.getTimeLimitSeconds() * 1000;
+        timeRemainingInMillis = gameMode.getTimeLimitSeconds() * 1000L;
+        maxTimeSinceResumeInMillis = gameMode.getTimeLimitSeconds() * 1000L;
         score = 0;
         wordsUsed = new LinkedHashSet<>();
         initializeWeights();


### PR DESCRIPTION
Fixes #348
However, the fix doesn't apply to the cases of 99,999,999 minutes and more - because 99,999,999 * 60 seconds = 5,999,999,940 seconds, which exceeds Java Integer max value, and `timeLimitSeconds` is Int. 

@pserwylo: perhaps it makes sense to introduce a sensible fixed upper time limit like Integer max value?