### PR TITLE
Ensure all letters are shuffled correctly (not just the first 15).

### DIFF
--- a/libraries/liblexica/src/main/java/com/serwylo/lexica/game/CharProbGenerator.java
+++ b/libraries/liblexica/src/main/java/com/serwylo/lexica/game/CharProbGenerator.java
@@ -116,8 +116,10 @@ public class CharProbGenerator {
             total += pq.peekProb();
         }
 
-        // shuffle the letters
-        for (int to = 15; to > 0; to--) {
+        // Although strictly not necessary because they were randomly chosen above, it is not
+        // uniformly random above - those with higher probabilities are probably selected first.
+        // Hence, we shuffle again.
+        for (int to = board.length - 1; to > 0; to--) {
             int from = rng.nextInt(to);
             String tmp = board[to];
             board[to] = board[from];


### PR DESCRIPTION
In theory, this will have some sort of impact on the number of words available on larger boards (beyond 4x4), but with a cursory test of a few board generations in English (UK), it didn't have a large impact.

Even if it does have a large impact, it is still better to do this right and address consequences as they come, rather than having a strange corner in the bottom right with less common letters.