### PR TITLE
Correctly show max score when viewing in-game found words.

### DIFF
--- a/app/src/main/java/com/serwylo/lexica/activities/score/ScoreCalculator.kt
+++ b/app/src/main/java/com/serwylo/lexica/activities/score/ScoreCalculator.kt
@@ -49,16 +49,8 @@ class ScoreCalculator(game: Game) {
 
             }
 
-            if (game.status == Game.GameStatus.GAME_FINISHED) {
-                possible.remove(w)
-            }
-
         }
 
-        maxScore = score
-
-        for (w in possible) {
-            maxScore += game.getWordScore(w)
-        }
+        maxScore = game.solutions.keys.sumOf { game.getWordScore(it) }
     }
 }


### PR DESCRIPTION
There was a performance optimisation to not calculate the word score for found words twice. It did this by calculating the current score, then when calculating the max score, only do so for the words which have not yet been scored.

To make it clearer what is going on, it now just re-counts if neccesary. It doesn't seem like this performance hit is worth the chance of (well, the actual) bugs.

Fixes #315.