### PR TITLE
Tidy preference screen.

### DIFF
--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -26,6 +26,4 @@
     <string name="word_length">Дължина на Думата</string>
 	<string name="letter_points">Точи за Букви</string>
 
-	<string name="pref_sounds_summary">Дали звуковите ефекти са разрешени или не</string>
-
-	</resources>
+</resources>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -10,7 +10,6 @@
     <string name="pref_boardSize">Mida del tauler</string>
     <string name="pref_timeLimit">Límit de temps</string>
     <string name="pref_sounds">Habilita el so</string>
-    <string name="pref_sounds_summary">Si voleu els efectes de so</string>
     <string name="dialog_about_title">Quant al Lexica</string>
     <string name="dialog_about_content">Toqueu la pantalla i mogueu el dit a les caselles adjacents per a lletrejar mots. Teniu tres minuts per trobar-hi tants mots com sigui possible.
 \n
@@ -58,7 +57,6 @@
     <string name="pref_breakdown">Mostra el detall dels mots més llargs</string>
     <string name="high_scores_reset">S\'han reinicialitzat les millors puntuacions.</string>
     <string name="pref_resetScores">Restableix les millors puntuacions</string>
-    <string name="pref_resetScores_summary">L\'aplicació enregistra les puntuacions més altes per a cadascuna de les configuracions anteriors. Toqueu aquí per a restablir-les totes a zero.</string>
     <string name="high_score">Millor puntuació</string>
     <string name="hint_colour">Color de la fitxa</string>
     <string name="tile_count">Nombre de mots</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -112,7 +112,6 @@
     <string name="multiplayer_lobby__join_when_ready">Až budou všichni hráči připraveni, připojte se ke hře.</string>
     <string name="multiplayer_lobby__join_game">Připojit se ke hře</string>
     <string name="multiplayer__share_invites">Sdílet pozvánky</string>
-    <string name="pref_sounds_summary">Zda mají být povoleny zvukové efekty</string>
     <string name="dialog_about_content">Dotýkejte se obrazovky a přesouvejte prst na sousední čtverce, abyste hláskovali slova. Máte tři minuty na to, abyste našli co nejvíce slov.
 \n
 \nBodování:
@@ -124,7 +123,6 @@
     <string name="pref_definitionProvider_summary">Vyberte poskytovatele definic, kterého chcete použít. Pokud vybraný poskytovatel není nainstalován, použije se online zdroj, například Wikislovník.</string>
     <string name="game_mode_sprint">Sprint</string>
     <string name="high_scores">Nejvyšší skóre</string>
-    <string name="pref_resetScores_summary">Nejvyšší skóre se sleduje pro každou kombinaci výše uvedených nastavení. Klepnutím na položku vynulujete všechna skóre.</string>
     <string name="pref_breakdown">Zobrazit rozdělení délky slova</string>
     <string name="pref_theme">Téma</string>
     <string name="pref_theme_dialog">Vyberte téma</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -38,7 +38,6 @@
     <string name="reset_scores_prompt">Er du sikker på at du vil nulstille alle de højeste scorer for alle spilmodus til nul\?</string>
     <string name="high_scores_reset">De højeste scorer blev nulstillet.</string>
     <string name="pref_resetScores">Nulstil højeste scorer</string>
-    <string name="pref_resetScores_summary">De højeste scorer spores for hver kombination af ovenstående indstillinger. Tryk for at nulstille alle scorer til nul.</string>
     <string name="high_score">Højeste score</string>
     <string name="total_score">Total score:</string>
     <string name="total_words">Totalt antal ord:</string>
@@ -81,7 +80,6 @@
     <string name="menu_save_game">Spar spilet</string>
     <string name="menu_rotate_board">Roter brættet</string>
     <string name="dialog_about_title">Om Lexica</string>
-    <string name="pref_sounds_summary">Hvorvidt lydeffekter skal påskrues</string>
     <string name="pref_sounds">Lyder påskruet</string>
     <string name="hint_colour">Flisfarve</string>
     <string name="tile_count">Antal ord</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -18,7 +18,6 @@
     <string name="pref_dict_en_GB">Englisch (UK)</string>
     <string name="pref_dict_en_US">Englisch (US)</string>
     <string name="pref_sounds">Klänge aktiviert</string>
-    <string name="pref_sounds_summary">Ob Soundeffekte aktiviert sind oder nicht</string>
     <string name="pref_timeLimit">Zeitbegrenzung</string>
     <string name="prefs">Einstellungen</string>
     <string name="restore_game">Spiel wiederherstellen</string>
@@ -38,7 +37,6 @@
     <string name="word_length">Wortlänge</string>
     <string name="value_max_percentage">%1$d/%2$d (%3$d%%)</string>
     <string name="high_score">Höchste Punktzahl</string>
-    <string name="pref_resetScores_summary">Die höchste Punktzahl wird für jede Kombination der oben genannten Einstellungen aufgezeichnet. Antippen, um alle Ergebnisse auf Null zurückzusetzen.</string>
     <string name="pref_resetScores">Höchste Punktzahlen zurücksetzen</string>
     <string name="high_scores_reset">Höchste Punktzahl wurde zurückgesetzt</string>
     <string name="reset_scores_prompt">Bist du dir sicher, dass du alle höchste Punktzahlen in allen Spielmodi zurücksetzen möchtest\?</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -10,7 +10,6 @@
     <string name="define_word"><u>Ορισμός</u> </string>
     <string name="pref_sounds">Ήχος ενεργοποιημένος</string>
     <string name="show_unique">Εμφάνιση μοναδικών λέξεων</string>
-    <string name="pref_sounds_summary">Εάν είναι ενεργοποιημένα τα ηχητικά εφέ ή όχι</string>
     <string name="menu_end_game">Τερματισμός παιχνιδιού</string>
     <string name="button_ok">Εντάξει</string>
     <string name="pref_dict_nl">Ολλανδικά</string>
@@ -35,7 +34,6 @@
     <string name="pref_dict_en_GB">Αγγλικά (ΗΒ)</string>
     <string name="total_score">Συνολική βαθμολογία:</string>
     <string name="pref_resetScores">Μηδενισμός υψηλών βαθμολογιών</string>
-    <string name="pref_resetScores_summary">Οι υψηλές βαθμολογίες παρακολουθούνται για κάθε συνδυασμό των παραπάνω ρυθμίσεων. Πατήστε για να μηδενίσετε όλες τις βαθμολογίες.</string>
     <string name="pref_timeLimit">Χρονικό όριο</string>
     <string name="word_length">Μήκος λέξης</string>
     <string name="view_word"><u>Προβολή</u></string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -98,7 +98,6 @@
     <string name="pref_dict_pt_BR_no_diacritics" tools:keep="@string/pref_dict_pt_BR">La portugala (brazila)</string>
     <string name="pref_dict_nl" tools:keep="@string/pref_dict_nl">La nederlanda</string>
     <string name="pref_dict_ca" tools:keep="@string/pref_dict_ca">La kataluna</string>
-    <string name="pref_resetScores_summary">Plej bonaj poentaroj registriĝas por ĉiu kombinaĵo de la ĉi-supraj agordoj. Tuŝetu por nuligi ĉiujn poentarojn.</string>
     <string name="whats_new_game_modes_description">La jenaj preferoj estis anstataŭigitaj per Ludaj Reĝimoj: Daŭro, grando de tabulo, minimuma vortolongo, tipo de poentaro, kaj reĝimo de sugestoj.
 \n
 \nVi povas ŝanĝi ludreĝimon ĉe la ĉefekrano aŭ krei vian propran. Plej bonaj poentaroj registriĝas laŭ ludreĝimo kaj vortaro.</string>
@@ -120,7 +119,6 @@
     <string name="pref_breakdown">Montri Distribuon de Vortolongoj</string>
     <string name="game_mode_letter_points_description">Gajni pli da poentoj post uzo de malpli oftaj literoj</string>
     <string name="input_game_mode_name_description">Por elekti ludreĝimon / registri plej bonajn poentarojn</string>
-    <string name="pref_sounds_summary">Ĉu ŝalti sonefektojn</string>
     <string name="pref_dict_ru_extended_description" tools:keep="@string/pref_dict_ru_extended_description">Inkluzivas gramatikajn kazojn kaj mallongigojn</string>
     <string name="pref_dict_ru_extended" tools:keep="@string/pref_dict_ru_extended">La rusa (etendita)</string>
     <string name="pref_dict_fr_FR_no_diacritics" tools:keep="@string/pref_dict_fr_FR_no_diacritics">La franca</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -10,7 +10,6 @@
     <string name="pref_boardSize">Tamaño del tablero</string>
     <string name="pref_timeLimit">Límite de tiempo</string>
     <string name="pref_sounds">Sonido habilitado</string>
-    <string name="pref_sounds_summary">Indica si los efectos de sonidos están habilitados o no</string>
     <string name="dialog_about_title">Sobre Léxica</string>
     <string name="dialog_about_content">Toca la pantalla y nueve tu dedo hacia las casillas adyacentes para deletrear la palabra. Tiene tres minutos para encontrar todas las palabras que puedas.
 \n
@@ -45,7 +44,6 @@
 \nComo un bono, las partes internas de Léxica se han actualizado para facilitar la futura adición de base de datos locales para guardar cada palabra encontrada y cada puntaje alto.</string>
     <string name="high_scores_reset">Los puntajes más altos han sido reseteados.</string>
     <string name="pref_resetScores">Resetea los puntajes más altos</string>
-    <string name="pref_resetScores_summary">Los puntajes más altos son guardados según la combinación de configuraciones para la partida. Toca para resetear las puntuaciones.</string>
     <string name="high_score">Puntaje más alto</string>
     <string name="score">Puntaje</string>
     <string name="pref_scoreType">Tipo de puntaje</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -20,7 +20,6 @@
     <string name="reset_scores_prompt">Kas sa oled kindel, et soovid kõikide mänguvariantide kõik senised rekordid kustutada\?</string>
     <string name="high_scores_reset">Kõik senised rekordid on kustutatud.</string>
     <string name="pref_resetScores">Nulli parimad tulemused</string>
-    <string name="pref_resetScores_summary">Parimate tulemuste osas peetakse arvet ülalpool toodud seadistuste iga kombinatsiooni kohta. Kõikide rekordite nullimiseks vajuta siia.</string>
     <string name="high_score">Parim tulemus</string>
     <string name="value_max_percentage">%1$d/%2$d (%3$d%%)</string>
     <string name="total_score">Tulemus kokku:</string>
@@ -35,7 +34,6 @@
     <string name="menu_end_game">Lõpeta mäng</string>
     <string name="menu_save_game">Salvesta mäng</string>
     <string name="menu_rotate_board">Pööra mängulauda</string>
-    <string name="pref_sounds_summary">Kas heliefektid on lubatud või mitte</string>
     <string name="pref_sounds">Helid on sisse lülitatud</string>
     <string name="hint_colour">Paani värv</string>
     <string name="tile_count">Sõnade arv</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -10,7 +10,6 @@
     <string name="pref_boardSize">اندازهٔ صفحه</string>
     <string name="pref_timeLimit">محدودیت زمان</string>
     <string name="pref_sounds">با صدا</string>
-    <string name="pref_sounds_summary">صدای بازی فعال است یا خیر</string>
     <string name="dialog_about_title">دربارهٔ لکسیکا</string>
     <string name="dialog_about_content">صفحه را لمس کرده و انگشت خود را برای املای کلمات به مربع های مجاور ببرید. سه دقیقه فرصت دارید تا حد ممکن کلمات را بیابید.
 \n
@@ -40,7 +39,6 @@
     <string name="letter_points">امتیاز هر حرف</string>
     <string name="score">امتیاز</string>
     <string name="high_score">امتیاز بالا</string>
-    <string name="pref_resetScores_summary">امتیازات برتر برای هر ترکیبی از تنظیمات بالا دنبال می‌شوند. برای بازنشانی همهٔ امتیازات به صفر، ضربه بزنید.</string>
     <string name="pref_resetScores">بازنشانی امتیازهای برتر</string>
     <string name="high_scores_reset">امتیازهای برتر بازنشانی شده است.</string>
     <string name="reset_scores_prompt">آیا مطمئن هستید که می‌خواهید همهٔ امتیازهای برتر را برای همهٔ حالت‌های بازی صفر کنید؟</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -37,7 +37,6 @@
     <string name="pref_definitionProvider">Määritelmien tarjoaja</string>
     <string name="pref_breakdown_summary">Näytetäänkö sanojen määrä eripituisille sanoille erikseen</string>
     <string name="pref_breakdown">Näytä sanojen pituuksien erittely</string>
-    <string name="pref_resetScores_summary">Ennätykset tallennetaan erikseen jokaiselle yhdistelmälle yllä olevia asetuksia. Paina nollataksesi kaikki pisteet.</string>
     <string name="reset_scores_prompt">Oletko varma, että halueat nollata kaikkien pelitilojen ennätykset\?</string>
     <string name="high_scores_reset">Ennätykset on nollattu.</string>
     <string name="pref_resetScores">Nollaa ennätykset</string>
@@ -58,7 +57,6 @@
 \n4x4-laudalla sanojen pitää olla vähintään kolmikirjaimisia. 5x5-laudalla sanojen pitää olla vähintään nelikirjaimisia. Kolmi- ja nelikirjaimet sanat ovat yhden pisteen arvoisia. Pidemmät sanat ovat useamman pisteen arvoisia. Erisnimiä ei lasketa.
 \n
 \n</string>
-    <string name="pref_sounds_summary">Käytetäänkö äänitehosteita vai ei</string>
     <string name="pref_sounds">Äänet käytössä</string>
     <string name="hint_colour">Laatan väri</string>
     <string name="tile_count">Sanojen määrä</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -10,7 +10,6 @@
     <string name="pref_boardSize">Taille du plateau</string>
     <string name="pref_timeLimit">Limite de Temps</string>
     <string name="pref_sounds">Sons activés</string>
-    <string name="pref_sounds_summary">Activer ou désactiver les effets sonores</string>
     <string name="dialog_about_title">À propos de Lexica</string>
     <string name="dialog_about_content">Touchez l\'écran et déplacez votre doigt vers un carré adjacent pour épeler les mots. Vous avez trois minutes pour trouver le plus de mots possible.
 \n
@@ -40,7 +39,6 @@
     <string name="letter_points">Valeur des lettres</string>
     <string name="score">Score</string>
     <string name="high_score">Meilleur score </string>
-    <string name="pref_resetScores_summary">Les meilleurs scores sont enregistrés pour chaque paramètrage ci-dessus. Appuyez ici pour effacer la mémoire.</string>
     <string name="pref_resetScores">Réinitialiser les meilleurs scores</string>
     <string name="high_scores_reset">Les meileurs résultats ont été réinitialisés.</string>
     <string name="reset_scores_prompt">Êtes-vous sûr(e) de vouloir réinitialiser tous les meilleurs résultats, et ce pour chaque mode de jeu \?</string>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -15,7 +15,6 @@
     <string name="reset_scores_prompt">האם אתה בטוח שברצונך לאפס את כל הנקודים הגבוהים עבור כל מצבי המשחק לאפס\?</string>
     <string name="high_scores_reset">ניקודים אופסו.</string>
     <string name="pref_resetScores">אפס ניקודים</string>
-    <string name="pref_resetScores_summary">מעקב אחר ניקודים גבוהים לכל שילוב של ההגדרות שלמעלה. הקש כדי לאפס את כל הציונים לאפס.</string>
     <string name="high_score">ניקוד גבוה</string>
     <string name="value_max_percentage">%1$d/%2$d (%3$d%%)</string>
     <string name="total_score">סך הניקוד:</string>
@@ -43,7 +42,6 @@
 \n
 \n</string>
     <string name="dialog_about_title">על Lexica</string>
-    <string name="pref_sounds_summary">בין אם אפקטים קוליים מופעלים ובין אם לא</string>
     <string name="pref_sounds">צלילים מופעלים</string>
     <string name="hint_colour">צבע אריח</string>
     <string name="tile_count">מספר מילים</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -15,7 +15,6 @@
     <string name="reset_scores_prompt">क्या आप वाकई सभी गेम मोड के लिए सभी उच्च स्कोर को शून्य पर रीसेट करना चाहते हैं\?</string>
     <string name="high_scores_reset">उच्च स्कोर रीसेट कर दिया गया है।</string>
     <string name="pref_resetScores">उच्च स्कोर रीसेट करें</string>
-    <string name="pref_resetScores_summary">उपरोक्त सेटिंग्स के प्रत्येक संयोजन के लिए उच्च स्कोर ट्रैक किए जाते हैं। सभी स्कोर शून्य पर रीसेट करने के लिए टैप करें।</string>
     <string name="high_score">उच्च स्कोर</string>
     <string name="value_max_percentage">%1$d/%2$d (%3$d%%)</string>
     <string name="total_score">कुल स्कोर:</string>
@@ -43,7 +42,6 @@
 \n
 \n</string>
     <string name="dialog_about_title">लेक्सिका के बारे में</string>
-    <string name="pref_sounds_summary">ध्वनि प्रभाव सक्षम हैं या नहीं</string>
     <string name="pref_sounds">आवाज़ सक्षम</string>
     <string name="hint_colour">टाइल के रंग</string>
     <string name="tile_count">शब्दों की संख्या</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -11,7 +11,6 @@
     <string name="pref_sounds">Zvukovi aktivirani</string>
     <string name="show_unique">Prikaži jedinstvene riječi</string>
     <string name="tile_count">Broj riječi</string>
-    <string name="pref_sounds_summary">Jesu li zvučni efekti aktivirani</string>
     <string name="menu_end_game">Završi igru</string>
     <string name="button_ok">U redu</string>
     <string name="pref_dict_nl">Nizozemski</string>
@@ -39,7 +38,6 @@
     <string name="pref_dict_en_GB">Engleski (UK)</string>
     <string name="total_score">Ukupni rezultat:</string>
     <string name="pref_resetScores">Poništi najbolje rezultate</string>
-    <string name="pref_resetScores_summary">Za svaku kombinaciju gore navedenih postavki prate se najbolji rezultati. Dodirni za poništavanje svih rezultata na nulu.</string>
     <string name="pref_timeLimit">Vremensko ograničenje</string>
     <string name="word_length">Duljina riječi</string>
     <string name="view_word"><u>Prikaži</u></string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -23,7 +23,6 @@
     <string name="word_length">Szóhossz</string>
     <string name="letter_points">Betűpontok</string>
     <string name="pref_sounds">Hangok engedélyezve</string>
-    <string name="pref_sounds_summary">A hangok legyenek-e engedélyezve vagy sem</string>
     <string name="dialog_about_title">A Lexica névjegye</string>
     <string name="dialog_about_content">Érintse meg a kijelzőt, és mozgassa az ujját a szomszédos négyzetekre a szavak betűzéséhez. Három perce van arra, hogy a lehető legtöbb szót megtalálja. 
 \n
@@ -50,7 +49,6 @@
     <string name="total_score">Összes pontszám:</string>
     <string name="value_max_percentage">%1$d/%2$d (%3$d%%)</string>
     <string name="high_score">Legjobb pontszám</string>
-    <string name="pref_resetScores_summary">A legjobb pontszámok a fenti beállítások minden egyes kombinációjánál követésre kerülnek. Koppintson az összes pontszám nullára történő visszaállításához.</string>
     <string name="pref_resetScores">Legjobb pontszámok visszaállítása</string>
     <string name="high_scores_reset">A legjobb pontszámok vissza lettek állítva.</string>
     <string name="reset_scores_prompt">Biztosan vissza szeretné állítani az összes legjobb pontszámot nullára az összes játéknál?</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -14,7 +14,6 @@
     <string name="pref_timeLimit">Batas Waktu</string>
     <string name="tile_count">Jumlah kata</string>
     <string name="pref_sounds">Suara Aktif</string>
-    <string name="pref_sounds_summary">Apa efek suara diaktifkan</string>
     <string name="dialog_refresh_title">Muat ulang papan</string>
     <string name="dialog_refresh_button">Muat ulang</string>
     <string name="dialog_about_title">Tentang Lexica</string>
@@ -145,5 +144,4 @@
     <string name="pref_hintMode">Modus</string>
     <string name="pref_hintMode_summary">Tampilkan jumlah kata masing-masing huruf dapat digunakan dalam</string>
     <string name="define_word"><u>Definisi</u> </string>
-    <string name="pref_resetScores_summary">Skor tinggi dilacak untuk setiap kombinasi dari pengaturan di atas. Ketuk untuk mengatur ulang semua skor ke nol.</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -9,7 +9,6 @@
     <string name="pref_boardSize">Dimensioni della tavola</string>
     <string name="pref_timeLimit">Limite di tempo</string>
     <string name="pref_sounds">Suoni abilitati</string>
-    <string name="pref_sounds_summary">Se i suoni sono abilitati oppure no</string>
     <string name="dialog_about_title">Informazioni su Lexica</string>
     <string name="pref_dict">Lessico</string>
     <string name="dialog_about_content">Tocca lo schermo e traccia col dito per scrivere le parole. Puoi passare da una casella ad un\'altra adiacente in verticale, orizzontale o diagonale. Hai tre minuti per trovare più parole che puoi.
@@ -61,7 +60,6 @@
     <string name="reset_scores_prompt">Sei sicuro/a di voler resettare tutti i punteggi migliori per tutte le modalità di gioco\?</string>
     <string name="high_scores_reset">I punteggi migliori sono stati resettati.</string>
     <string name="pref_resetScores">Resetta i punteggi migliori</string>
-    <string name="pref_resetScores_summary">I punteggi migliori vengono tracciati per ogni combinazione delle impostazioni di cui sopra. Tocca per ripristinare tutti i punteggi a zero.</string>
     <string name="pref_breakdown_summary">Se il contatore di parole mostri i conteggi per lunghezza di parola</string>
     <string name="pref_definitionProvider_dictionaryProvider_online">In linea</string>
     <string name="pref_definitionProvider_dialog">Seleziona il fornitore di definizioni</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -10,7 +10,6 @@
     <string name="pref_boardSize">ボード サイズ</string>
     <string name="pref_timeLimit">制限時間</string>
     <string name="pref_sounds">サウンドが有効です</string>
-    <string name="pref_sounds_summary">効果音を有効にするかどうか</string>
     <string name="dialog_about_title">Lexica について</string>
     <string name="dialog_about_content">画面にタッチして、単語のつづりに隣接するマスに指を移動します。3 分間に可能な限り多くの単語を探してください。
 \n
@@ -40,7 +39,6 @@
     <string name="letter_points">文字のポイント</string>
     <string name="score">スコア</string>
     <string name="high_score">ハイスコア</string>
-    <string name="pref_resetScores_summary">ハイスコアは、上記設定の組み合わせごとに記録されます。タップすると、すべてのスコアをゼロにリセットします。</string>
     <string name="pref_resetScores">ハイスコアをリセット</string>
     <string name="high_scores_reset">ハイスコアをリセットしました。</string>
     <string name="reset_scores_prompt">すべてのゲームモードのすべてのハイスコアをゼロにリセットしてもよろしいですか?</string>

--- a/app/src/main/res/values-kmr/strings.xml
+++ b/app/src/main/res/values-kmr/strings.xml
@@ -46,7 +46,6 @@
     <string name="reset_scores_prompt">Tu pê bawer î ku dixwazî hemû pûanên bilind ên hemû modên lîstikê jê bibî\?</string>
     <string name="high_scores_reset">Pûanên bilind hat jêbirin.</string>
     <string name="pref_resetScores">Pûanên Bilind Jê bibe</string>
-    <string name="pref_resetScores_summary">Bo her kombînasyona sazkariyên jor pûanên bilind tê şopandin. Bo hemû pûanan jê bibî, lê bitepîne.</string>
     <string name="high_scores">Pûanên Herî Bilind</string>
     <string name="high_score">Pûana Herî Bilind</string>
     <string name="value_max_percentage">%1$d/%2$d (%3$d%%)</string>
@@ -63,7 +62,6 @@
     <string name="dialog_refresh_button">Nû bike</string>
     <string name="dialog_refresh_content">Hay lê hebe ku tu bi hevrikên xwe re li ser heman hûnanê dilîzî, ji ber wê piştî nûkirinê, baş zanibe ku te hemû vexwendinên xwe dîsa şandine.</string>
     <string name="dialog_refresh_title">Hûnanê nû bike</string>
-    <string name="pref_sounds_summary">Efektên dengan çalak e yan na</string>
     <string name="pref_sounds">Dengan bike çalak</string>
     <string name="hint_colour">Rengê xiştê</string>
     <string name="tile_count">Hejmara peyvan</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -80,7 +80,6 @@
     <string name="pref_breakdown">Rodyti žodžių ilgio suskirstymą</string>
     <string name="reset_scores_prompt">Ar tikrai norite iš naujo nustatyti nulinius visų žaidimo režimų rekordus\?</string>
     <string name="high_scores_reset">Rekordai bus nustatyti iš naujo.</string>
-    <string name="pref_resetScores_summary">Aukšti rekordai stebimi pagal kiekvieną pirmiau nurodytų nustatymų derinį. Bakstelėkite , jei norite iš naujo nustatyti visus rekordus į nulį.</string>
     <string name="pref_resetScores">Iš naujo nustatyti rekordus</string>
     <string name="high_scores">Rekordai</string>
     <string name="high_score">Rekordas</string>
@@ -115,7 +114,6 @@
     <string name="dialog_refresh_button">Atnaujinti</string>
     <string name="dialog_refresh_content">Norėdami užtikrinti, kad žaidžiate prie tos pačios lentos kaip ir jūsų varžovai, po atnaujinimo būtinai iš naujo išsiųskite visus kvietimus.</string>
     <string name="dialog_refresh_title">Atnaujinti lentą</string>
-    <string name="pref_sounds_summary">Ar įjungti garso efektai</string>
     <string name="pref_sounds">Įjungti garsai</string>
     <string name="hint_colour">Plytelių spalva</string>
     <string name="tile_count">Žodžių skaičius</string>

--- a/app/src/main/res/values-mr/strings.xml
+++ b/app/src/main/res/values-mr/strings.xml
@@ -13,7 +13,6 @@
     <string name="reset_scores_prompt">आपल्याला खात्री आहे की आपण सर्व गेम मोडसाठी सर्व उच्च गुणांक शून्यावर रीसेट करू इच्छिता\?</string>
     <string name="high_scores_reset">उच्च गुणांक रीसेट केले गेले आहेत.</string>
     <string name="pref_resetScores">उच्च गुणांक रीसेट करा</string>
-    <string name="pref_resetScores_summary">वरील सेटिंग्जच्या प्रत्येक संयोजनासाठी उच्च गुणांक ट्रॅक केले जातात. सर्व गुणांक शून्यावर रीसेट करण्यासाठी टॅप करा.</string>
     <string name="high_score">उच्च गुणांक</string>
     <string name="value_max_percentage">%1$d/%2$d (%3$d%%)</string>
     <string name="total_score">एकूण गुणांक:</string>
@@ -41,7 +40,6 @@
 \n
 \n</string>
     <string name="dialog_about_title">लेक्सिका बद्दल</string>
-    <string name="pref_sounds_summary">ध्वनी प्रभाव सक्षम आहेत की नाही</string>
     <string name="pref_sounds">ध्वनी सक्षम केला</string>
     <string name="hint_colour">टाइल रंग</string>
     <string name="tile_count">शब्दसंख्या</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -13,7 +13,6 @@
     <string name="word_length">Ordlengde</string>
     <string name="letter_points">Bokstavpoeng</string>
     <string name="pref_sounds">Lyder</string>
-    <string name="pref_sounds_summary">Hvorvidt lydeffekter er påskrudd</string>
     <string name="dialog_about_title">Om Lexica</string>
     <string name="dialog_about_content">Trykk på skjermen og flytt fingeren til hosliggende firkanter for å stave ord. Du har tre minutter på å finne så mange ord som mulig.
 \n
@@ -40,7 +39,6 @@
     <string name="total_score">Total poengsum:</string>
     <string name="value_max_percentage">%1$d/%2$d (%3$d%%)</string>
     <string name="high_score">Bestenotering</string>
-    <string name="pref_resetScores_summary">Høyeste poengsum spores for hver kombinasjon av ovennevnte innstillinger. Trykk for å tilbakestille alle poengsummer til null.</string>
     <string name="pref_resetScores">Tilbakestill bestenoteringer</string>
     <string name="high_scores_reset">Bestenoteringslisten har blitt tilbakestilt.</string>
     <string name="reset_scores_prompt">Tilbakestill alle bestenoteringer\?</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -10,7 +10,6 @@
     <string name="pref_boardSize">Bordgrootte</string>
     <string name="pref_timeLimit">Tijdslimiet</string>
     <string name="pref_sounds">Geluiden ingeschakeld</string>
-    <string name="pref_sounds_summary">Geluidseffecten in-/uitschakelen</string>
     <string name="dialog_about_title">Over Lexica</string>
     <string name="dialog_about_content">Raak het scherm aan en veeg met je vinger over aangrenzende vakjes om woorden samen te stellen. Je hebt 3 minuten de tijd om zo veel mogelijk woorden te vinden.
 \n
@@ -40,7 +39,6 @@
     <string name="letter_points">Letterpunten</string>
     <string name="score">Score</string>
     <string name="high_score">Topscore</string>
-    <string name="pref_resetScores_summary">Topscores worden bijgehouden voor elke combinatie van bovenstaande instellingen. Druk om alle scores terug te zetten op nul.</string>
     <string name="pref_resetScores">Topscores terugzetten op nul</string>
     <string name="high_scores_reset">De topscores zijn teruggezet op nul.</string>
     <string name="reset_scores_prompt">Weet je zeker dat je alle topscores van alle spelmodi wilt terugzetten op nul?</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -24,7 +24,6 @@
     <string name="word_length">Długość słowa</string>
     <string name="letter_points">Punty Liter</string>
     <string name="pref_sounds">Włącz Dźwięki</string>
-    <string name="pref_sounds_summary">Czy efekty dźwiękowe są włączone</string>
     <string name="dialog_about_title">O Lexica</string>
     <string name="dialog_about_content">Dotknij ekranu i przesuń palec do sąsiednich kwadratów, aby przeliterować słowa. Masz trzy minuty na znalezienie jak największej liczby słów. 
 \n
@@ -51,7 +50,6 @@
     <string name="total_score">Łączny wynik:</string>
     <string name="value_max_percentage">%1$d/%2$d (%3$d%%)</string>
     <string name="high_score">Najlepszy wynik</string>
-    <string name="pref_resetScores_summary">Najlepsze wyniki są śledzone dla każdej kombinacji powyższych ustawień. Stuknij, aby zresetować wszystkie wyniki do zera.</string>
     <string name="pref_resetScores">Zresetuj najlepsze wyniki</string>
     <string name="high_scores_reset">Najlepsze wyniki zostały zresetowane.</string>
     <string name="reset_scores_prompt">Czy na pewno chcesz zresetować wszystkie najlepsze wyniki dla wszystkich trybów gry do zera\?</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -11,7 +11,6 @@
     <string name="pref_sounds">Sons Ativados</string>
     <string name="show_unique">Mostrar Palavras Únicas</string>
     <string name="tile_count">Número de palavras</string>
-    <string name="pref_sounds_summary">Se os efeitos sonoros estão ou não ativados</string>
     <string name="menu_end_game">Finalizar Jogo</string>
     <string name="button_ok">OK</string>
     <string name="pref_dict_nl">Holandês</string>
@@ -39,7 +38,6 @@
     <string name="pref_dict_en_GB">Inglês (Reino Unido)</string>
     <string name="total_score">Pontuação Total:</string>
     <string name="pref_resetScores">Zerar Recordes</string>
-    <string name="pref_resetScores_summary">Os recordes são registrados para cada combinação das configurações acima. Toque para zerar todas as pontuações.</string>
     <string name="pref_timeLimit">Tempo Limite</string>
     <string name="word_length">Tamanho da Palavra</string>
     <string name="view_word"><u>Mostrar</u></string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -37,7 +37,6 @@
     <string name="reset_scores_prompt">Deseja realmente zerar os recordes de todos os modos de jogo\?</string>
     <string name="high_scores_reset">Os recordes foram zerados.</string>
     <string name="pref_resetScores">Zerar recordes</string>
-    <string name="pref_resetScores_summary">Os recordes são registados para cada combinação das configurações acima. Toque para zerar todas as pontuações.</string>
     <string name="high_score">Recorde</string>
     <string name="value_max_percentage">%1$d/%2$d (%3$d%%)</string>
     <string name="total_score">Pontuação total:</string>
@@ -64,7 +63,6 @@
 \n 
 \n</string>
     <string name="dialog_about_title">Sobre o Lexica</string>
-    <string name="pref_sounds_summary">Se os efeitos sonoros estão ou não ativados</string>
     <string name="pref_sounds">Sons ativados</string>
     <string name="pref_hintMode_summary">Mostra a quantidade de palavras em que cada letra pode ser usada</string>
     <string name="pref_hintMode">Modo de dicas</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -19,7 +19,6 @@
     <string name="reset_scores_prompt">Deseja realmente zerar os recordes de todos os modos de jogo\?</string>
     <string name="high_scores_reset">Os recordes foram zerados.</string>
     <string name="pref_resetScores">Zerar recordes</string>
-    <string name="pref_resetScores_summary">Os recordes são registados para cada combinação das configurações acima. Toque para zerar todas as pontuações.</string>
     <string name="high_score">Recorde</string>
     <string name="value_max_percentage">%1$d/%2$d (%3$d%%)</string>
     <string name="total_score">Pontuação total:</string>
@@ -46,7 +45,6 @@
 \n
 \n</string>
     <string name="dialog_about_title">Sobre o Lexica</string>
-    <string name="pref_sounds_summary">Se os efeitos sonoros estão ou não ativados</string>
     <string name="pref_sounds">Sons ativados</string>
     <string name="hint_colour">Cor do título</string>
     <string name="tile_count">Quantidade de palavras</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -21,7 +21,6 @@
     <string name="word_length">По длине слов</string>
     <string name="letter_points">По очкам букв</string>
     <string name="pref_sounds">Звуки</string>
-    <string name="pref_sounds_summary">Использовать звуковые эффекты или нет</string>
     <string name="dialog_about_title">О Lexica</string>
     <string name="dialog_about_content">
 	Коснитесь экрана и водите пальцем по примыкающим друг к другу квадратам для составления слов. 
@@ -50,7 +49,6 @@
     <string name="total_score">Очки:</string>
     <string name="value_max_percentage">%1$d/%2$d (%3$d%%)</string>
     <string name="high_score">Лучший результат</string>
-    <string name="pref_resetScores_summary">Рекорды записываются для каждой комбинации настроек. Нажмите, чтобы сбросить все рекорды.</string>
     <string name="pref_resetScores">Сбросить рекорды</string>
     <string name="high_scores_reset">Рекорды были удалены.</string>
     <string name="reset_scores_prompt">Вы уверены в том, что хотите удалить рекорды для всех режимов игры?</string>

--- a/app/src/main/res/values-sat/strings.xml
+++ b/app/src/main/res/values-sat/strings.xml
@@ -16,7 +16,6 @@
     <string name="reset_scores_prompt">ᱟᱢ ᱡᱷᱚᱛᱚ ᱞᱮᱠᱷᱟ ᱛᱮ ᱡᱷᱚᱛᱚ ᱠᱷᱮᱞ ᱠᱚ ᱨᱮᱭᱟᱜ ᱢᱚᱰ ᱠᱚ ᱡᱷᱚᱛᱚ ᱦᱟᱭ ᱥᱠᱚᱨ ᱠᱚ ᱐ ᱥᱟᱱᱟᱢ ᱠᱟᱱᱟ ᱥᱮ\?</string>
     <string name="high_scores_reset">ᱦᱟᱭ ᱥᱠᱚᱨ ᱫᱚ ᱨᱤᱥᱮᱴ ᱟᱠᱟᱱᱟ ᱾</string>
     <string name="pref_resetScores">ᱦᱟᱭ ᱥᱠᱚᱨ ᱠᱚ ᱨᱤᱥᱚᱴ ᱢᱮ</string>
-    <string name="pref_resetScores_summary">"ᱪᱮᱛᱟᱱ ᱥᱟᱡᱟᱣ ᱠᱷᱚᱱ ᱨᱮᱭᱟᱜ ᱢᱮᱞ ᱛᱮ ᱦᱟᱭ ᱥᱠᱚᱨ ᱴᱨᱟᱠ ᱚᱜᱼᱟ ᱾ ᱡᱷᱚᱛᱚ ᱥᱠᱚᱨ ᱠᱚ ᱐ ᱛᱮ ᱨᱤᱥᱮᱴ ᱞᱟᱹᱜᱤᱫ  ᱚᱛᱟᱭ ᱢᱮ ᱾"</string>
     <string name="high_score">ᱡᱟᱭ ᱥᱠᱚᱨ</string>
     <string name="total_score">ᱢᱩᱴ ᱥᱠᱚᱨ:</string>
     <string name="total_words">ᱢᱩᱴ ᱟᱲᱟ ᱠᱚ:</string>
@@ -43,7 +42,6 @@
     <string name="menu_save_game">ᱠᱷᱮᱞ ᱥᱟᱸᱪᱟᱣ</string>
     <string name="menu_rotate_board">ᱵᱚᱰ ᱟᱹᱪᱩᱨ ᱢᱮ</string>
     <string name="dialog_about_title">ᱞᱮᱠᱥᱤᱠᱟ ᱵᱟᱵᱚᱛ</string>
-    <string name="pref_sounds_summary">ᱥᱟᱲᱮ ᱤᱯᱷᱮᱠᱼᱴ ᱮᱢ ᱮᱱᱟ ᱥᱮ ᱵᱟᱝᱟ</string>
     <string name="pref_sounds">ᱥᱟᱲᱮ ᱮᱢᱮᱱᱟ</string>
     <string name="hint_colour">ᱴᱟᱭᱤᱞ ᱨᱚᱸᱝ</string>
     <string name="tile_count">ᱟᱲᱟ ᱟᱮᱭᱟᱜ ᱮᱞ</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -37,7 +37,6 @@
 \n
 \n</string>
     <string name="pref_breakdown_summary">Či sa dĺžky slov majú zobraziť v rozpise slov alebo nie</string>
-    <string name="pref_resetScores_summary">Najvyššie skóre je sledované pre každú kombináciu vyššie uvedených nastavení. Ťuknutím na položku vynulujete skóre u všetkých nastavení.</string>
     <string name="hide_unique">Skryť jedinečné slová</string>
     <string name="show_unique">Zobraziť jedinečné slová</string>
     <string name="pref_hintMode_summary">Ukáže počet slov, v ktorých sa dané písmeno vyskytuje</string>
@@ -72,7 +71,6 @@
     <string name="menu_end_game">Ukončiť hru</string>
     <string name="menu_save_game">Uložiť hru</string>
     <string name="menu_rotate_board">Otočiť dosku</string>
-    <string name="pref_sounds_summary">Či sú alebo nie sú povolené zvukové efekty</string>
     <string name="sort">Zoradiť</string>
     <string name="theme_high_contrast">Vysoký Kontrast</string>
     <string name="menu_new_game_mode">Nový</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -29,7 +29,6 @@
     <string name="tile_count">Antalet ord</string>
     <string name="hint_colour">Panelfärg</string>
     <string name="pref_sounds">Ljud aktiverat</string>
-    <string name="pref_sounds_summary">Huravida ljud är på eller inte</string>
     <string name="dialog_about_title">Om Lexica</string>
     <string name="dialog_about_content">Sätt fingret på skärmen på första bokstaven, dra till intilliggande bokstäver för att bilda ett ord. Du har tre minuter på dig att hitta så många ord som möjligt.
 \n
@@ -56,7 +55,6 @@
     <string name="total_score">Sammanlagda poäng:</string>
     <string name="value_max_percentage">%1$d/%2$d (%3$d%%)</string>
     <string name="high_score">Rekord</string>
-    <string name="pref_resetScores_summary">Rekord är sparade för varje kombination av inställningarna ovan. Tryck för att återställa alla rekord till noll.</string>
     <string name="pref_resetScores">Återställ rekord</string>
     <string name="high_scores_reset">Rekord har blivit återställda.</string>
     <string name="reset_scores_prompt">Är du säker på att du vill återställa alla rekord för alla spellägen till noll\?</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -23,7 +23,6 @@
     <string name="word_length">Sözcük Uzunluğu</string>
     <string name="letter_points">Harf Puanı</string>
     <string name="pref_sounds">Sesleri Etkinleştir</string>
-    <string name="pref_sounds_summary">Ses efektlerinin etkinleştirilip etkinleştirilmediği</string>
     <string name="dialog_about_title">Lexica Hakkında</string>
     <string name="dialog_about_content">Kelimeleri hecelemek için ekrana dokunun ve parmağınızı bitişik karelere doğru hareket ettirin. Mümkün olduğunca çok kelime bulmak için üç dakikanız var.
 \n
@@ -50,7 +49,6 @@
     <string name="total_score">Toplam Puan:</string>
     <string name="value_max_percentage">%1$d/%2$d (%3$d%%)</string>
     <string name="high_score">Yüksek Puan</string>
-    <string name="pref_resetScores_summary">Yukarıdaki ayarların her bir kombinasyonu için yüksek puanlar izlenir. Tüm puanları sıfırlamak için dokunun.</string>
     <string name="pref_resetScores">Yüksek Puanları Sıfırla</string>
     <string name="high_scores_reset">Yüksek puanlar sıfırlandı.</string>
     <string name="reset_scores_prompt">Tüm oyun modları için yüksek puanları sıfırlamak istediğinizden emin misiniz\?</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -21,7 +21,6 @@
     <string name="word_length">За довжиною слів</string>
     <string name="letter_points">За балами букв</string>
     <string name="pref_sounds">Звуки увімкнено</string>
-    <string name="pref_sounds_summary">Чи ввімкнено звукові ефекти</string>
     <string name="dialog_about_title">Про Lexica</string>
     <string name="dialog_about_content">Торкніться екрана і проведіть пальцем по сусідніх квадратах для складання слів. Спробуйте знайти якнайбільше слів за вказаний час.
 \n
@@ -48,7 +47,6 @@
     <string name="total_score">Загальний рахунок:</string>
     <string name="value_max_percentage">%1$d/%2$d (%3$d%%)</string>
     <string name="high_score">Рекорд</string>
-    <string name="pref_resetScores_summary">Рекорди зберігаються для кожної комбінації налаштувань. Натисніть, щоб обнулити всі рекорди.</string>
     <string name="pref_resetScores">Обнулити рекорди</string>
     <string name="high_scores_reset">Рекорди обнулено.</string>
     <string name="reset_scores_prompt">Ви впевнені, що хочете видалити рекорди для всіх режимів гри\?</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -65,7 +65,6 @@
     <string name="reset_scores_prompt">Bạn có chắc bạn muốn đặt lại tất cả điểm cao của tất cả chế độ chơi về không không\?</string>
     <string name="high_scores_reset">Điểm cao đã được đặt lại.</string>
     <string name="pref_resetScores">Đặt lại điểm cao</string>
-    <string name="pref_resetScores_summary">Điểm cao được theo dõi cho mỗi sự kết hợp các cài đặt ở trên. Nhấn để đặt lại tất cả số điểm về không.</string>
     <string name="high_scores">Điểm cao</string>
     <string name="high_score">Điểm cao</string>
     <string name="value_max_percentage">%1$d/%2$d (%3$d%%)</string>
@@ -100,7 +99,6 @@
     <string name="dialog_refresh_button">Làm mới</string>
     <string name="dialog_refresh_content">Để chắc chắn là bạn chơi trên cùng một bảng với đối phương, hãy đảm bảo là bạn gửi lại các lời mời sau khi làm mới.</string>
     <string name="dialog_refresh_title">Làm mới bảng</string>
-    <string name="pref_sounds_summary">Hiệu ứng âm thanh có được bật hay không</string>
     <string name="pref_sounds">Bật âm thanh</string>
     <string name="hint_colour">Màu ô</string>
     <string name="tile_count">Số lượng các từ</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -10,7 +10,6 @@
     <string name="pref_boardSize">版面</string>
     <string name="pref_timeLimit">时限</string>
     <string name="pref_sounds">音效</string>
-    <string name="pref_sounds_summary">选择游戏会否发出音效</string>
     <string name="dialog_about_title">关于Lexica</string>
     <string name="dialog_about_content">您要在3分钟内拼出版面上所有单词。要拼出单词，请先触碰屏幕后滑动至相邻的方块。 
 \n 
@@ -40,7 +39,6 @@
     <string name="letter_points">字母分数</string>
     <string name="score">分数</string>
     <string name="high_score">高分纪录</string>
-    <string name="pref_resetScores_summary">游戏为每个游戏模式纪录最高分，按此以重设所有分数纪录至零分。</string>
     <string name="pref_resetScores">重设高分纪录</string>
     <string name="high_scores_reset">您已重设高分纪录。</string>
     <string name="reset_scores_prompt">您确定要重设所有分数至零分？</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -14,9 +14,8 @@
 	<string name="pref_timeLimit">時限</string>
 
 	<string name="pref_sounds">音效</string>
-	<string name="pref_sounds_summary">選擇遊戲會否發出音效</string>
 
-	<string name="dialog_about_title">關於Lexica</string>
+    <string name="dialog_about_title">關於Lexica</string>
 	<string name="menu_rotate_board">旋轉圖版</string>
 	<string name="menu_save_game">儲存遊戲</string>
 	<string name="menu_end_game">結束遊戲</string>
@@ -52,8 +51,7 @@
 
 	<string name="score">分數</string>
 	<string name="high_score">高分紀錄</string>
-	<string name="pref_resetScores_summary">遊戲為每個遊戲模式紀錄最高分，按此以重設所有分數紀錄至零分。</string>
-	<string name="pref_resetScores">重設高分紀錄</string>
+    <string name="pref_resetScores">重設高分紀錄</string>
     <string name="high_scores_reset">您已重設高分紀錄。</string>
 	<string name="reset_scores_prompt">您確定要重設所有分數至零分？</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,8 +44,7 @@
     <string name="pref_hintMode_summary">Shows the number of words each letter can be used in</string>
     <string name="tile_count">Number of words</string>
     <string name="hint_colour">Tile colour</string>
-    <string name="pref_sounds">Sounds Enabled</string>
-    <string name="pref_sounds_summary">Whether or not sound effects are enabled</string>
+    <string name="pref_sounds">Sound Effects</string>
     <string name="dialog_refresh_title">Refresh board</string>
     <string name="dialog_refresh_content">To ensure you play the same board as your opponents, make sure to resend any invites after refreshing.</string>
     <string name="dialog_refresh_button">Refresh</string>
@@ -84,14 +83,13 @@
     <string name="value_max_percentage">%1$d/%2$d (%3$d%%)</string>
     <string name="high_score">High Score</string>
     <string name="high_scores">High Scores</string>
-    <string name="pref_resetScores_summary">High scores are tracked for each combination of the above settings. Tap to reset all scores to zero.</string>
     <string name="pref_resetScores">Reset High Scores</string>
     <string name="high_scores_reset">High scores have been reset.</string>
-    <string name="reset_scores_prompt">Are you sure you want to reset all high scores for all game modes to zero?</string>
+    <string name="reset_scores_prompt">Are you sure you want to reset all high scores for all game modes to zero? This cannot be undone.</string>
     <string name="pref_breakdown">Show Word Length Breakdown</string>
     <string name="pref_breakdown_summary">Whether or not the word count shows counts by word length</string>
     <string name="pref_definitionProvider">Definition Provider</string>
-    <string name="pref_definitionProvider_summary">Select a definition provider to use. If the selected provider is not installed, an online source such as Wiktionary will be used.</string>
+    <string name="pref_definitionProvider_summary">If the selected provider is not installed, an online source such as Wiktionary will be used.</string>
     <string name="pref_definitionProvider_dialog">Select Definition Provider</string>
     <string name="pref_definitionProvider_dictionaryProvider_online">Online</string>
     <string name="pref_theme">Theme</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -1,18 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<PreferenceScreen
-	xmlns:android="http://schemas.android.com/apk/res/android">
-
-	<PreferenceScreen
-		android:key="resetScores"
-		android:title="@string/pref_resetScores"
-		android:summary="@string/pref_resetScores_summary"
-		android:iconSpaceReserved="false"
-	/>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+	xmlns:app="http://schemas.android.com/apk/res-auto">
 
 	<ListPreference
 		android:key="theme"
 		android:title="@string/pref_theme"
+		app:useSimpleSummaryProvider="true"
 		android:entries="@array/theme_choices_entries"
 		android:entryValues="@array/theme_choices_entryvalues"
 		android:defaultValue="light"
@@ -21,11 +15,9 @@
 	/>
 
 	<CheckBoxPreference
-		android:key="soundsEnabled"
-		android:title="@string/pref_sounds"
-		android:summary="@string/pref_sounds_summary"
 		android:iconSpaceReserved="false"
-	/>
+		android:key="soundsEnabled"
+		android:title="@string/pref_sounds" />
 
 	<!-- The default value of "duckduckgo" is a legacy option which means "Online source" -->
 	<ListPreference
@@ -38,5 +30,9 @@
 		android:dialogTitle="@string/pref_definitionProvider_dialog"
 		android:iconSpaceReserved="false"
 	/>
+	<PreferenceScreen
+		android:iconSpaceReserved="false"
+		android:key="resetScores"
+		android:title="@string/pref_resetScores" />
 
 </PreferenceScreen>


### PR DESCRIPTION
* Order is more sensible (dangerous reset high scores last)
* Selected theme is shown on screen.
* Remove unnecessary or outdated parts of summary text from most options.

Fixes #178.