### PR TITLE
Actually bump for release v3.11.0.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "com.serwylo.lexica"
         minSdkVersion 18
         targetSdkVersion 33
-        versionCode 30014
-        versionName "3.10.0"
+        versionCode 30015
+        versionName "3.11.0"
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }

--- a/fastlane/metadata/android/en-US/changelogs/30015.txt
+++ b/fastlane/metadata/android/en-US/changelogs/30015.txt
@@ -1,0 +1,4 @@
+Dictionaries:
+ * Added Turkish dictionary (thanks to feedback from @bmusalli).
+
+Please provide feedback/report issues at https://github.com/lexica/lexica/issues.


### PR DESCRIPTION
Last attempt didn't increase version number, so F-Droid (correctly) didn't publish a new version when we tagged v3.11.0. Will remove v3.11.0 tag and recreate it.