### PR TITLE
Handle time limit related crashes

### DIFF
--- a/app/src/main/java/com/serwylo/lexica/NewGameModeActivity.kt
+++ b/app/src/main/java/com/serwylo/lexica/NewGameModeActivity.kt
@@ -3,8 +3,10 @@ package com.serwylo.lexica
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
+import android.view.View
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
+import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.textfield.TextInputEditText
 import com.serwylo.lexica.databinding.NewGameModeBinding
 import com.serwylo.lexica.db.Database
@@ -44,8 +46,26 @@ class NewGameModeActivity : AppCompatActivity() {
         return super.onOptionsItemSelected(item)
     }
 
-    private fun TextInputEditText.isValid() = with(this.text) {
-        isNullOrBlank().not() && Integer.parseInt(toString()) > 0
+    private fun TextInputEditText.isValid() : Boolean = with(this.text.toString()) {
+        return@with when {
+            isBlank() -> {
+                binding.root.showSnackbar(context.getString(R.string.time_limit_must_be_set))
+                false
+            }
+            toLong() * 60 > MAX_TIME_LIMIT_IN_MINUTES -> {
+                binding.root.showSnackbar(context.getString(R.string.max_time_limit))
+                false
+            }
+            Integer.parseInt(this) <= 0 -> {
+                binding.root.showSnackbar(context.getString(R.string.time_limit_too_short))
+                false
+            }
+            else -> true
+        }
+    }
+
+    private fun View.showSnackbar(text: String) {
+        Snackbar.make(this, text, Snackbar.LENGTH_LONG).show()
     }
 
     private fun createNewGameMode() {
@@ -147,5 +167,9 @@ class NewGameModeActivity : AppCompatActivity() {
 
         return "hint_none"
 
+    }
+
+    private companion object {
+        const val MAX_TIME_LIMIT_IN_MINUTES = 2592000
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -150,6 +150,9 @@
     <string name="invite__dont_have_lexica_installed_web">Or try out Lexica in the Browser (beta):</string>
     <string name="send_challenge_invite_to">Send challenge to…</string>
     <string name="send_multiplayer_invite_to">Send invite to…</string>
+    <string name="time_limit_must_be_set">Time limit must be set</string>
+    <string name="max_time_limit">Max time limit is 30 days (43200 minutes)</string>
+    <string name="time_limit_too_short">Time limit too short</string>
     <plurals name="num_available_words_in_game__tap_to_refresh">
         <item quantity="one">%1$d word (tap to refresh)</item>
         <item quantity="other">%1$d words (tap to refresh)</item>


### PR DESCRIPTION
Fixes #377 - the crashes should occur no more.

As part of this fix, I've incorporated the logic that @pserwylo hinted at in a comment on my previous fix (#351) - introducing a sensible time limit in days rather than millions of seconds. I've however arbitrarily chosen 30 days rather than 20 days - this is easily changeable. Also, in case the time limit exceeds that threshold / is zero / is blank, a suitable Snackbar message is shown.  One of them is visible in the example screenshot below:
<img src="https://github.com/lexica/lexica/assets/9060663/e480fa48-4ea5-4d8a-9b51-6b74ade77a9c" width="190" height="380">
