### PR TITLE
Fix preferences crash on android 14+

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -136,7 +136,7 @@
 			</intent-filter>
         </activity>
 
-        <activity android:name=".SettingsActivity" android:exported="false" android:parentActivityName=".MainMenuActivity">
+        <activity android:name=".SettingsActivity" android:exported="true" android:parentActivityName=".MainMenuActivity">
 			<meta-data android:name="android.support.PARENT_ACTIVITY" android:value=".MainMenuActivity" />
 			<intent-filter>
 				<action android:name="com.serwylo.lexica.action.CONFIGURE" />


### PR DESCRIPTION
Reference :

https://developer.android.com/about/versions/14/behavior-changes-14#security

I believe there are no security implications changing the SettingsActivity exported status to true. 

If there's concern, then we can change the codes on MainMenuActivity to use explicit intent instead.